### PR TITLE
#1763

### DIFF
--- a/lib/api/streamer.js
+++ b/lib/api/streamer.js
@@ -114,15 +114,24 @@ Streamer.prototype._addReportUpdatesListeners = function(emitter) {
 
   // Listens to report updates
   emitter.on('report:status', function(report) {
-    Report.findById(report._id, function(err, report) {
-      if (err) self.emit('error', err);
-      else self.emit('reportStatusChanged', report);
-    });
+    Report.findById(report._id).
+            populate({path: '_source', select: 'nickname type'}).
+            populate({path: '_incident', select: 'title'}).
+            exec(function(err, report){
+              if (err) self.emit('error', err);
+              else self.emit('reportStatusChanged', report);
+            });
   });
 
   // Listens to changes in report incidents
   emitter.on('report:incident', function(report) {
-    self.emit('reportIncidentChanged', report);
+    Report.findById(report._id).
+            populate({path: '_source', select: 'nickname type'}).
+            populate({path: '_incident', select: 'title'}).
+            exec(function(err, report){
+              if (err) self.emit('error', err);
+              else self.emit('reportIncidentChanged', report);
+            });
   });
 };
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,6 +1,7 @@
 // Connects to database.
 
 var mongoose = require('mongoose');
+var _ = require('underscore');
 var config = require('../config/secrets').get();
 
 // Find database records using pagination
@@ -26,11 +27,21 @@ mongoose.Model.findPage = function(filters, page, options, callback) {
   options = options || {};
   options.limit = PAGE_LIMIT;
   options.skip = page * PAGE_LIMIT;
+  
+  var populateOptions = options.populate || [];
+  if (options.populate) delete options.populate;
 
   model.count(filters, function(err, count) {
     if (err) return callback(err);
+    
     var result = {total: count};
-    model.find(filters, null, options, function(err, results) {
+    var query = model.find(filters, null, options);
+    
+    _.each(populateOptions, function(item){
+      query.populate(item);
+    });
+    
+    query.exec(function(err, results) {
       if (err) return callback(err);
       result.results = results;
       callback(null, result);

--- a/lib/fetching/bot.js
+++ b/lib/fetching/bot.js
@@ -34,7 +34,6 @@ Bot.prototype.start = function() {
       // Need to add _source foreign key reference here b/c ContentService doesn't know about Source.
       report_data._source = self.source._id;
       report_data._sourceType = self.source.type;
-      report_data._sourceNickname = self.source.nickname;
 
       var drops = self.queue.drops;
       self.queue.add(report_data);


### PR DESCRIPTION
1. Removed _sourceNickname from report model. This can be populated from source id, which is already stored in report
2. Before saving report, nullify _incident if it is empty. This is needed because we use mongoose method to populate related document, and it has to be a valid value or null
3. Before saving, always set _statusWasModified and _incidentWasModified so that unnecessary events are not raised if nothing is modified
4. When _statusWasModified or _incidentWasModified is raised, load related source and incident and emit that to the client

Please note that with the above, the client should stop using report._sourceNickname and use report._source.nickname, report._source.type and report._incident.title