### PR TITLE
1950: Added post hook to Incident model  remove operation

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -48,6 +48,16 @@ schema.post('save', function() {
   schema.emit('incident:save', {_id: this._id.toString()});
 });
 
+schema.post('remove', function() {
+  Report.find({_incident:this._id.toString()}, function(err,reports){
+    if(err) log('master', 'debug', err.stack);
+    reports.forEach(function(report){
+      report._incident=null;
+      report.save();
+    })
+  });
+});
+
 var Incident = mongoose.model('Incident', schema);
 schema.plugin(autoIncrement.plugin, { model: 'Incident', field: 'idnum', startAt: 1 });
 

--- a/test/models.delete.incident.with.reports.js
+++ b/test/models.delete.incident.with.reports.js
@@ -1,0 +1,83 @@
+require('./init');
+var expect = require('chai').expect;
+var Incident = require('../models/incident');
+var Report = require('../models/report');
+var _ = require('underscore');
+var async = require('async');
+var User = require('../models/user');
+
+function loadUser(done) {
+  User.findOne({}, function(err, u) {
+    user = u;
+    done();
+  });
+}
+var id1;
+var id2;
+function removeAll(done){
+  Report.remove({}, function(){
+    Incident.remove({},done);
+  });
+}
+function createIncidents(done) { 
+  Incident.create([
+    {title: 'Not so important incident', veracity: null, closed: true},
+    {title: 'Very important incident', veracity: null, closed: true}
+  ], function(err, incident1, incident2){
+    id1 =incident1._id.toString();
+    id2 =incident2._id.toString();
+    done();
+  });
+}
+
+function createReport(done) {
+  Report.create([
+    {_incident: id1},
+    {_incident: id1},
+    {_incident: id2},
+    {_incident: id2},
+    {_incident: id2},
+    
+  ], done);
+}
+
+function removeIncident(done){
+  Incident.findOne({_id:id1}, function(err, incident){
+    incident.remove(done);
+  });
+  
+}
+describe('Deleting an incident that has associated reports', function() {
+  before(function(done) {
+    async.series([loadUser, removeAll, createIncidents, createReport, removeIncident], done);
+  });
+
+
+  it('should remove the incident', function(done) {
+    Incident.find({_id:id1}, function(err, incidents){
+      expect(incidents.length).to.equal(0);
+      done();
+    });
+  });
+    
+  it('should not remove the other incident', function(done) {
+    Incident.find({_id:id2}, function(err, incidents){
+      expect(incidents.length).to.equal(1);
+      done();
+    });
+  });
+  it('should not affect other reports', function(done) {
+    Report.find({_incident:id2}, function(err, reports){
+      expect(reports.length).to.equal(3);
+      done();
+    });    
+  });
+  
+  it('should remove reference to the incidents in the right reports', function(done) {
+    Report.find({_incident:id1}, function(err, reports){
+      expect(reports.length).to.equal(0);
+      done();
+    });
+  });
+      
+});


### PR DESCRIPTION
Deleting incidents did not update the reports which linked to them. New mongoose middleware fixes it 
```javascript
schema.post('remove',function(
...
```