### PR TITLE
4208 allow numbers in nicknames

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -6,7 +6,7 @@
 var database = require('../lib/database');
 var mongoose = database.mongoose;
 var Schema = mongoose.Schema;
-var validate = require('mongoose-validator').validate;
+var validate = require('mongoose-validator');
 var _ = require('underscore');
 var autoIncrement = require('mongoose-auto-increment');
 var listenTo = require('mongoose-listento');
@@ -14,8 +14,13 @@ var Report = require('./report');
 
 require('../lib/error');
 
+var length_validator = validate({
+  validator: 'isLength',
+  arguments: [0, 32]
+});
+
 var schema = new mongoose.Schema({
-  title: {type: String, required: true, validate: validate('max', 32)},
+  title: {type: String, required: true, validate: length_validator},
   locationName: String,
   latitude: Number,
   longitude: Number,

--- a/models/source.js
+++ b/models/source.js
@@ -6,17 +6,27 @@
 
 var database = require('../lib/database');
 var mongoose = database.mongoose;
-var validate = require('mongoose-validator').validate;
+var validate = require('mongoose-validator');
 var _ = require('underscore');
 require('../lib/error');
 
 var EVENTS_TO_RETURN = 50;
 
+var length_validator = validate({
+  validator: 'isLength',
+  arguments: [0, 20]
+});
+
+var url_validator = validate({
+  validator: 'isURL',
+  passIfEmpty: true
+});
+
 var sourceSchema = new mongoose.Schema({
   media: String,
-  nickname: {type: String, required: true, validate: validate('max', 20)},
+  nickname: {type: String, required: true, validate: length_validator},
   resource_id: String,
-  url: {type: String, validate: validate({passIfEmpty: true}, 'isUrl')},
+  url: {type: String, validate: url_validator},
   keywords: String,
   enabled: {type: Boolean, default: true},
   events: {type: Array, default: []},

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mongoose-auto-increment": "^3.2.0",
     "mongoose-listento": "0.0.4",
     "mongoose-text-search": "0.0.2",
-    "mongoose-validator": "~0.2.2",
+    "mongoose-validator": "^1.2.4",
     "nconf": "~0.7.1",
     "node-sass": "~0.8.6",
     "nodemailer": "~0.6.3",

--- a/test/lib.api.v1.source-facebook-controller.test.js
+++ b/test/lib.api.v1.source-facebook-controller.test.js
@@ -1,0 +1,42 @@
+require('./init');
+var expect = require('chai').expect;
+var request = require('supertest');
+var _ = require('underscore');
+var sourceController = require('../lib/api/v1/source-controller')();
+
+describe('Facebook source controller', function() {
+  describe('POST /api/v1/source', function() {
+    var sources = [
+      'nytimes',
+      'bbcburmese',
+      'NLDParty',
+      '134634523373717',
+      '308669855916817',
+      '150773224985493',
+      'MattressFactory',
+      'darkmatterpoetry'
+    ];
+
+    _.each(sources, function(source_name) {
+      it('should create a new facebook source', function(done) {
+        var source = {
+          nickname: source_name,
+          media: 'facebook',
+          url: 'https://www.facebook.com/' + source_name
+        };
+
+        request(sourceController)
+          .post('/api/v1/source')
+          .send(source)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) return done(err);
+            expect(res.body).to.have.property('_id');
+            source._id = res.body._id;
+            compare.call(this, res.body, source);
+            done();
+          });
+      });
+    });
+  });
+});

--- a/test/lib.api.v1.source-facebook-controller.test.js
+++ b/test/lib.api.v1.source-facebook-controller.test.js
@@ -18,7 +18,7 @@ describe('Facebook source controller', function() {
     ];
 
     _.each(sources, function(source_name) {
-      it('should create a new facebook source', function(done) {
+      it('should create a new facebook source ' + source_name, function(done) {
         var source = {
           nickname: source_name,
           media: 'facebook',

--- a/test/models.source.test.js
+++ b/test/models.source.test.js
@@ -8,7 +8,7 @@ describe('Source attributes', function() {
       expect(err).to.have.keys(['message', 'name', 'errors']);
       expect(err.errors).to.have.keys(['nickname', 'url']);
       expect(err.errors.nickname.type).to.equal('required');
-      expect(err.errors.url.message).to.contain('Invalid URL');
+      expect(err.errors.url.message).to.contain('Validator failed for path `url` with value `hey`');
       done();
     });
   });


### PR DESCRIPTION
In the legacy version of `mongoose-validator`, `validate('max', 20)` would fail on strings that begin with a number greater than 20. Updating `mongoose-validator` solves this.