### PR TITLE
Dockerize aggie

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ The following need to be installed.
   `openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365`
   - This will allow you to start the server but it will generate unsafe warnings in the browser. You will need a real trusted certificate for production use.
   - Adding the `-nodes` flag will generate an unencrypted private key, allowing you to run tests without going through a password prompt
-1. Run `npm install && node install.js` from the project directory.
-  - This installs all dependencies, adds indexing support to MongoDB, creates an admin user, and concatenates the angular application.
-1. In your terminal during 'npm install', a user and password were generated. You will use these credentials to log into the application. Example: `"admin" user created with password "password"`.
+1. Run `npm install` from the project directory.
+  - This installs all dependencies and concatenates the angular application.
 1. Run `npm install -g gulp mocha`.
   - This installs gulp and mocha globally so they can be run from the command line for testing.
 1. Run `npm install -g migrate`.
   - This installs node-migrate globally.
 1. To start server, run `npm start`.
+  - In your terminal, a user and password were generated. You will use these credentials to log into the application. Example: `"admin" user created with password "password"`.
 1. Navigate to `localhost:3000` in your browser.
   - This will show you the running site. Login with the user name and password from your terminal mentioned above.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following need to be installed.
   `openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365`
   - This will allow you to start the server but it will generate unsafe warnings in the browser. You will need a real trusted certificate for production use.
   - Adding the `-nodes` flag will generate an unencrypted private key, allowing you to run tests without going through a password prompt
-1. Run `npm install` from the project directory.
+1. Run `npm install && node install.js` from the project directory.
   - This installs all dependencies, adds indexing support to MongoDB, creates an admin user, and concatenates the angular application.
 1. In your terminal during 'npm install', a user and password were generated. You will use these credentials to log into the application. Example: `"admin" user created with password "password"`.
 1. Run `npm install -g gulp mocha`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,4 @@ RUN npm install --global gulp && npm install --unsafe-perm=true
 
 EXPOSE 3000
 
-CMD node install.js && npm start
+CMD npm start

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,20 +8,19 @@ WORKDIR /usr/src/
 # WORKDIR aggie
 
 # we use branch for testing first
-RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie & git checkout dockerize-aggie
+RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie && git checkout dockerize-aggie
 
 # Eventually we can install from master
 # RUN git clone https://github.com/TID-Lab/aggie.git
 
 WORKDIR aggie
 
-
 RUN mv config/secrets.json.example config/secrets.json
 
 # RUN npm install --production
 
 # Uncomment when using git clone
-RUN npm install
+RUN npm install --global gulp && npm install --unsafe-perm=true
 
 EXPOSE 3000
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:0.10
+
+WORKDIR /usr/src/
+
+# Using local version of aggie for debugging
+# RUN mkdir aggie
+# COPY . aggie/
+# WORKDIR aggie
+
+# we use branch for testing first
+RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie & git checkout dockerize-aggie
+
+# Eventually we can install from master
+# RUN git clone https://github.com/TID-Lab/aggie.git
+
+WORKDIR aggie
+
+
+RUN mv config/secrets.json.example config/secrets.json
+
+# RUN npm install --production
+
+# Uncomment when using git clone
+RUN npm install
+
+EXPOSE 3000
+
+CMD node install.js && npm start

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,4 +26,4 @@ RUN npm install --global gulp && npm install --unsafe-perm=true
 
 EXPOSE 3000
 
-CMD node install.js && npm start
+CMD node install.js && npm test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,11 @@ RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie && git checkout m
 WORKDIR aggie
 
 RUN mv config/secrets.json.example config/secrets.json
-RUN openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes
+RUN openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"
 
 # Uncomment when using git clone
-RUN npm install --global gulp forever && npm install --unsafe-perm=true
+RUN npm install --global gulp && npm install --unsafe-perm=true
 
 EXPOSE 3000
 
-CMD node install.js && forever start app.js
+CMD node install.js && npm start

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM node:0.10
 
 WORKDIR /usr/src/
 
+RUN curl -L https://npmjs.org/install.sh | sh
+
 # Using local version of aggie for debugging
 # RUN mkdir aggie
 # COPY . aggie/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,26 +4,17 @@ WORKDIR /usr/src/
 
 RUN curl -L https://npmjs.org/install.sh | sh
 
-# Using local version of aggie for debugging
-# RUN mkdir aggie
-# COPY . aggie/
-# WORKDIR aggie
-
-# we use branch for testing first
-RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie && git checkout dockerize-aggie
-
 # Eventually we can install from master
-# RUN git clone https://github.com/TID-Lab/aggie.git
+RUN git clone https://github.com/TID-Lab/aggie.git && cd aggie && git checkout master
 
 WORKDIR aggie
 
 RUN mv config/secrets.json.example config/secrets.json
-
-# RUN npm install --production
+RUN openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes
 
 # Uncomment when using git clone
-RUN npm install --global gulp && npm install --unsafe-perm=true
+RUN npm install --global gulp forever && npm install --unsafe-perm=true
 
 EXPOSE 3000
 
-CMD node install.js && npm test
+CMD node install.js && forever start app.js

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN mv config/secrets.json.example config/secrets.json
 RUN openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"
 
 # Uncomment when using git clone
-RUN npm install --global gulp && npm install --unsafe-perm=true
+RUN npm install --global gulp forever && npm install --unsafe-perm=true
 
 EXPOSE 3000
 
-CMD npm start
+CMD forever -c "npm start" .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ web:
   environment:
     - MONGO_HOST=db
   ports:
-    - "80:3000"
+    - "443:3000"
 db:
   image: mongo:2.6.11
   ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ web:
   ports:
     - "80:3000"
 db:
-  image: mongo:latest
+  image: mongo:2.6.11
   ports:
      - "27017:27017"
   command: "--smallfiles --logpath=/dev/null"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+web:
+  image: tid-lab/aggie-test
+  links:
+    - db
+  environment:
+    - MONGO_HOST=db
+  ports:
+    - "80:3000"
+db:
+  image: mongo:latest
+  ports:
+     - "27017:27017"
+  command: "--smallfiles --logpath=/dev/null"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 web:
-  image: unucs/aggie:docker
+  build: .
   links:
     - db
   environment:
@@ -8,8 +8,6 @@ web:
     - "80:3000"
 db:
   image: mongo:2.6.11
-  volumes:
-    - /usr/share/aggie-data:/data/db
   ports:
-     - "27017:27017"
+     - "27020:27017"
   command: "--smallfiles --logpath=/dev/null"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 web:
-  image: tid-lab/aggie-test
+  image: unucs/aggie:docker
   links:
     - db
   environment:
@@ -8,6 +8,8 @@ web:
     - "80:3000"
 db:
   image: mongo:2.6.11
+  volumes:
+    - /usr/share/aggie-data:/data/db
   ports:
      - "27017:27017"
   command: "--smallfiles --logpath=/dev/null"

--- a/install.js
+++ b/install.js
@@ -10,7 +10,13 @@ var tasks = [];
 // Enable full-text indexing for Reports
 function enableIndexing(callback) {
   // Wait for database connection
-  setTimeout(function() {
+  database.mongoose.connection.on('error', function(err) {
+    console.error('mongoose connection error (retrying): ', err);
+    setTimeout(function() {
+      database.mongoose.connect(database.connectURL);
+    }, 200);
+  });
+  database.mongoose.connection.once('open', function() {
     // Enable database-level text search
     database.mongoose.connections[0].db.admin().command({setParameter: 1, textSearchEnabled: true}, function(err, res) {
       if (err) console.error(err);
@@ -21,7 +27,7 @@ function enableIndexing(callback) {
         callback();
       });
     });
-  }, 1000);
+  });
 };
 tasks.push(enableIndexing);
 

--- a/lib/api/authentication.js
+++ b/lib/api/authentication.js
@@ -7,6 +7,7 @@ var User = require('../../models/user');
 var passport = require('passport');
 var LocalStrategy = require('passport-local').Strategy;
 var config = require('../../config/secrets').get();
+var database = require('../../lib/database.js');
 var _ = require('underscore');
 
 module.exports = function(app) {
@@ -16,8 +17,10 @@ module.exports = function(app) {
   // Configure session storage
   auth.key = 'connect.sid';
   auth.stubKey = 'aggie.auth';
-  auth.stubCookie = {path: '/', httpOnly: true, maxAge: 864e9};
-  auth.store = new MongoStore(config.mongodb);
+  auth.stubCookie = { path: '/', httpOnly: true, maxAge: 864e9 };
+
+  //Old library version uses mongoose_connection rather than mongooseConnection
+  auth.store = new MongoStore({ mongoose_connection: database.mongoose.connection });
   auth.secret = config.secret;
   auth.session = express.session({
     key: auth.key,

--- a/lib/database.js
+++ b/lib/database.js
@@ -37,7 +37,7 @@ mongoose.Model.findPage = function(filters, page, options, callback) {
   }
 
   // execute count and find in parallel fashion to avoid waiting for each other
-  async.parallel([ 
+  async.parallel([
     model.count.bind(model, filters),
     function (callback) {
       var query = model.find(filters, null, options);
@@ -67,10 +67,15 @@ Database.prototype.getConnectURL = function(config) {
     if (config.username && config.password) {
       connectionURL += config.username + ':' + config.password + '@';
     }
-    connectionURL += config.host;
-    if (config.port) connectionURL += ':' + config.port;
-    connectionURL += '/' + config.db;
+
+    connectionURL += process.env.MONGO_HOST || config.host;
+    if (process.env.MONGO_PORT) {
+      connectionURL += ':' + config.port;
+    } else if (config.port) connectionURL += ':' + config.port;
+    db = process.env.MONGO_AGGIE_DB || config.db;
+    connectionURL += '/' + db;
   }
+
   return connectionURL;
 };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/TID-Lab/aggie.git"
   },
   "scripts": {
-    "postinstall": "node install.js && gulp angular",
+    "postinstall": "gulp angular",
     "start": "node app.js",
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "scripts": {
     "postinstall": "gulp angular",
+    "prestart": "node install.js",
     "start": "node app.js",
+    "pretest": "node install.js",
     "test": "mocha"
   },
   "dependencies": {

--- a/test/init.js
+++ b/test/init.js
@@ -2,7 +2,7 @@ process.env.NODE_ENV = 'test';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var host = process.env.MONGO_HOST || 'localhost';
-var dbConnectURL = process.env.MONGO_CONNECTION_URL = 'mongodb://' + host + 'aggie-test';
+var dbConnectURL = process.env.MONGO_CONNECTION_URL = 'mongodb://' + host + '/aggie-test';
 var database = require('../lib/database');
 var Report = require('../models/report');
 var User = require('../models/user');

--- a/test/init.js
+++ b/test/init.js
@@ -1,7 +1,8 @@
 process.env.NODE_ENV = 'test';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-var dbConnectURL = process.env.MONGO_CONNECTION_URL = 'mongodb://localhost/aggie-test';
+var host = process.env.MONGO_HOST || 'localhost';
+var dbConnectURL = process.env.MONGO_CONNECTION_URL = 'mongodb://' + host + 'aggie-test';
 var database = require('../lib/database');
 var Report = require('../models/report');
 var User = require('../models/user');


### PR DESCRIPTION
Dockerfile and docker-compose used to ease deployment of single
instance of aggie. To test, run in docker folder:
```docker-compose up```
This will set up Aggie at `https://localhost`.

`node install.js` is now run before `npm test` and `npm start`, rather
than after `npm install`, which may be a minor inconvenience to those
running without docker.