### PR TITLE
4599 add incident from report page

### DIFF
--- a/lib/api/v1/report-controller.js
+++ b/lib/api/v1/report-controller.js
@@ -141,7 +141,7 @@ module.exports = function(app, user) {
       if (reports.length === 0) return res.send(200);
       var remaining = reports.length;
       reports.forEach(function(report) {
-        // Update the incidentId in the report
+        report.read = true;
         report._incident = req.body.incident;
         report.save(function(err) {
           if (err) return res.send(err.status, err.message);

--- a/public/angular/js/controllers/incidents/form_modal.js
+++ b/public/angular/js/controllers/incidents/form_modal.js
@@ -13,7 +13,7 @@ angular.module('Aggie')
   'FlashService',
   function($rootScope, $scope, $q, $state, $modal, $modalStack, $location, Incident, Report, flash) {
 
-    $scope.create = function (report) {
+    $scope.create = function(reports) {
       $modalStack.dismissAll();
       var modalInstance = $modal.open({
         controller: 'IncidentFormModalInstanceController',
@@ -22,29 +22,31 @@ angular.module('Aggie')
           users: ['User', function(User) {
             return User.query().$promise;
           }],
-          incident: function () {
+          incident: function() {
             return {
               veracity: null,
               closed: false
             };
           },
-          report: function () {
-            return report;
+          reports: function() {
+            return reports;
           }
         }
       });
 
       modalInstance.result.then(function(incident) {
         Incident.create(incident, function(inc) {
-          if (report) {
+          if (reports) {
             var batchMode = $location.url() === '/reports/batch';
-            report.read = true;
-            report._incident = inc._id;
-            Report.update({id: report._id}, report, function () {
+            var ids = reports.map(function(report) {
+              return report._id;
+            });
+
+            Report.linkToIncident({ids: ids, incident: inc._id}, function () {
               if (batchMode) {
                 $rootScope.$state.go('batch', {}, { reload: true });
               } else {
-                $rootScope.$state.go('reports', { r: report }, { reload: false });
+                $rootScope.$state.go('reports', { r: reports[0] }, { reload: false });
               }
             });
           } else {
@@ -69,8 +71,8 @@ angular.module('Aggie')
           incident: function() {
             return incident;
           },
-          report: function () {
-            return null;
+          reports: function() {
+            return [];
           }
         }
       });
@@ -104,14 +106,14 @@ angular.module('Aggie')
   'veracityOptions',
   'users',
   'incident',
-  'report',
-  function($scope, $modalInstance, incidentStatusOptions, veracityOptions, users, incident, report) {
+  'reports',
+  function($scope, $modalInstance, incidentStatusOptions, veracityOptions, users, incident, reports) {
     $scope.incident = angular.copy(incident);
     $scope.users = users;
     $scope.veracity = veracityOptions;
     $scope.showErrors = false;
-    $scope.report = report;
-    $scope.minimal = !!report;
+    $scope.reports = reports;
+    $scope.minimal = Boolean(reports);
     $scope.minimalLatLng = true;
 
     $scope.save = function(form) {

--- a/public/angular/js/controllers/incidents/report_incident_modal.js
+++ b/public/angular/js/controllers/incidents/report_incident_modal.js
@@ -34,16 +34,10 @@ angular.module('Aggie')
       });
 
       modalInstance.result.then(function(incidentId) {
-        //report.read = true;
-        var ids = [];
-        reports.map(function(report) {
-          //Update report in web
-          report._incident = incidentId;
-          ids.push(report._id);
-          return report;
+        var ids = reports.map(function(report) {
+          return report._id;
         });
 
-        //Update report in server
         Report.linkToIncident({ids: ids, incident: incidentId});
       });
     };

--- a/public/angular/templates/incidents/report_incident_modal.html
+++ b/public/angular/templates/incidents/report_incident_modal.html
@@ -6,12 +6,11 @@
     </h4>
   </div>
   <div class="modal-body">
-
-    <p ng-hide="incidents" class="info">Sorry, but we couldn't find any incidents. You can <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(report)">create a new incident</button>.</p>
-
+    <p ng-hide="incidents" class="info">Sorry, but we couldn't find any incidents. You can <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(reports)">create a new incident</button>.</p>
+    
     <div ng-show="incidents">
 
-      <p class='info'>Click an incident below to which you would like to add the report. Or you can <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(report)">create a new incident</button>.</p>
+      <p class='info'>Click an incident below to which you would like to add the report. Or you can <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(reports)">create a new incident</button>.</p>
 
       <div ng-include="'/templates/incidents/table.html'"></div>
 

--- a/public/angular/templates/reports/table.html
+++ b/public/angular/templates/reports/table.html
@@ -37,14 +37,9 @@
         <a href="/reports/{{r._id}}">{{ (r.content || '[No Content]') | stripHtml }}</a>
       </td>
       <td class="expand incident text-center relative" ng-hide="pageType == 'show-incident'">
-        <div ng-if="incidents.length">
+        <div>
           <a ng-controller="IncidentSelectModalController" ng-click="setIncident([r])" class="table-primary">
             <strong ng-if="r._incident && incidentsById[r._incident]">{{ incidentsById[r._incident].title | strLimit: 40 }}</strong>
-            <strong ng-if="!r._incident">Add</strong>
-          </a>
-        </div>
-        <div ng-if="!incidents.length">
-          <a ng-controller="IncidentFormModalController" ng-click="create(r)" class="table-primary">
             <strong ng-if="!r._incident">Add</strong>
           </a>
         </div>


### PR DESCRIPTION
Now Adding an incident to a single or multiple report works better. Incident can be a new one or an old one. Newly created incidents are fetched so that linked reports show the incident title without the need for a browser refresh.

This also fixes Bug #4599: Should not be redirecting to incident page when creating incident via report page