### PR TITLE
4797: Fixed raced condition when increasing totalReports

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -70,14 +70,11 @@ schema.plugin(autoIncrement.plugin, { model: 'Incident', field: 'idnum', startAt
 
 schema.listenTo(Report, 'change:incident', function(prevIncident, newIncident) {
   if (prevIncident !== newIncident) {
-    Incident.findByIdAndUpdate(prevIncident, { $inc: { totalReports: -1 } }, function(err, incident) {
-      if (err || !incident) return;
-    });
+    //Callbacks added to execute query immediately
+    Incident.findByIdAndUpdate(prevIncident, { $inc: { totalReports: -1 } }, function(err, incident) {});
   }
 
-  Incident.findByIdAndUpdate(newIncident, { $inc: { totalReports: 1 } }, function(err, incident) {
-    if (err || !incident) return;
-  });
+  Incident.findByIdAndUpdate(newIncident, { $inc: { totalReports: 1 } }, function(err, incident) {});
 
 });
 

--- a/models/incident.js
+++ b/models/incident.js
@@ -33,7 +33,7 @@ var schema = new mongoose.Schema({
   escalated: {type: Boolean, default: false, required: true},
   closed: {type: Boolean, default: false, required: true},
   idnum: {type: Number, required: true},
-  totalReports: {type: Number, default: 0},
+  totalReports: {type: Number, default: 0, min: 0},
   notes: String,
 });
 
@@ -69,20 +69,16 @@ var Incident = mongoose.model('Incident', schema);
 schema.plugin(autoIncrement.plugin, { model: 'Incident', field: 'idnum', startAt: 1 });
 
 schema.listenTo(Report, 'change:incident', function(prevIncident, newIncident) {
-  Incident.findById(prevIncident || newIncident, function(err, incident) {
+  if (prevIncident !== newIncident) {
+    Incident.findByIdAndUpdate(prevIncident, { $inc: { totalReports: -1 } }, function(err, incident) {
+      if (err || !incident) return;
+    });
+  }
+
+  Incident.findByIdAndUpdate(newIncident, { $inc: { totalReports: 1 } }, function(err, incident) {
     if (err || !incident) return;
-    var total = incident.totalReports;
-
-    if (prevIncident) {
-      total = (total > 0) ? total - 1 : 0;
-    } else if (newIncident) {
-      total = (total) ? total + 1 : 1;
-    }
-
-    incident.totalReports = total;
-
-    incident.save();
   });
+
 });
 
 // Query incidents based on passed query data


### PR DESCRIPTION
Linking reports to incident fired consecutives db finds to the same incident which updated the values in the callback. Now, we use atomic call findByIdAndUpdate.

Added test to check fix.