### PR TITLE
4602 source errors not disabling

### DIFF
--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -93,6 +93,12 @@ BotMaster.prototype.disableBot = function(bot) {
 BotMaster.prototype._addSourceListeners = function(emitter) {
   var self = this;
 
+  emitter.removeAllListeners('source:save');
+  emitter.removeAllListeners('source:remove');
+  emitter.removeAllListeners('source:enable');
+  emitter.removeAllListeners('source:disable');
+  Source.schema.removeAllListeners('source:disable');
+
   // Load bot when source is saved
   emitter.on('source:save', function(source) {
     // We pass the ID here as that's all we might have.
@@ -116,6 +122,12 @@ BotMaster.prototype._addSourceListeners = function(emitter) {
     var bot = self._getBot(source._id);
     if (bot) bot.stop();
   });
+
+  // Listen to `disable` event from the fetching process
+  Source.schema.on('source:disable', function(source) {
+    self._getBot(source._id).stop();
+  });
+
 };
 
 // Control bot master status remotely and other settings' changes

--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -1,5 +1,6 @@
 // Creates and destroys bots as sources are created, enabled, disabled, destroyed, etc.
 // Watches for fetching to be turned on and off and disables/enables bots accordingly.
+'use strict';
 
 var _ = require('underscore');
 var Source = require('../../models/source');
@@ -9,16 +10,16 @@ var util = require('util');
 var config = require('../../config/secrets');
 var async = require('async');
 
-var BotMaster = function() {
+function BotMaster() {
   this.bots = [];
   this.enabled = config.get().fetching;
-};
+}
 
 util.inherits(BotMaster, EventEmitter);
 
 BotMaster.prototype.init = function(callback) {
-  this._loadAll(callback || function(){});
-}
+  this._loadAll(callback || _.noop);
+};
 
 // Initialize event listeners
 BotMaster.prototype.addListeners = function(type, emitter) {
@@ -96,7 +97,7 @@ BotMaster.prototype._addSourceListeners = function(emitter) {
   // Load bot when source is saved
   emitter.on('source:save', function(source) {
     // We pass the ID here as that's all we might have.
-    self._loadOne(source._id, function(){});
+    self._loadOne(source._id, function() {});
   });
 
   // Kill bots when removed from datbase
@@ -152,9 +153,11 @@ BotMaster.prototype._addSettingsListeners = function(emitter) {
 BotMaster.prototype._loadAll = function(callback) {
   var self = this;
   // Find sources from the database
-  Source.find({media: {'$ne': null }}, function(err, sources) {
+  Source.find({ media: { $ne: null } }, function(err, sources) {
     if (err) return callback(err);
-    async.each(sources, function(s,c){ self._loadOne(s,c); }, callback);
+    async.each(sources, function(s, c) {
+      self._loadOne(s, c);
+    }, callback);
   });
 };
 
@@ -164,8 +167,8 @@ BotMaster.prototype._loadOne = function(sourceObjOrId, callback) {
   var self = this;
 
   // Resolve argument.
-  var sourceId = (sourceObjOrId instanceof Object) ? sourceObjOrId._id : sourceObjOrId;
-  var source = (sourceObjOrId instanceof Object) ? sourceObjOrId : null;
+  var sourceId = sourceObjOrId instanceof Object ? sourceObjOrId._id : sourceObjOrId;
+  var source = sourceObjOrId instanceof Object ? sourceObjOrId : null;
 
   // If bot for this source already exists, kill so that it can be re-added
   var bot = this._getBot(sourceId);
@@ -193,7 +196,7 @@ BotMaster.prototype._add = function(bot) {
   this.on('settingsUpdated:' + bot.source.media, function() {
     bot.contentService.reloadSettings();
   });
-  bot.on('report', function(report_data) {
+  bot.on('report', function() {
     self.emit('bot:report', bot);
   });
   bot.on('empty', function() {

--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -93,12 +93,6 @@ BotMaster.prototype.disableBot = function(bot) {
 BotMaster.prototype._addSourceListeners = function(emitter) {
   var self = this;
 
-  emitter.removeAllListeners('source:save');
-  emitter.removeAllListeners('source:remove');
-  emitter.removeAllListeners('source:enable');
-  emitter.removeAllListeners('source:disable');
-  Source.schema.removeAllListeners('source:disable');
-
   // Load bot when source is saved
   emitter.on('source:save', function(source) {
     // We pass the ID here as that's all we might have.


### PR DESCRIPTION
Previously, source errors only disabled the source in the database. Now, the fetching process also listens to its own sources for a disable event, stopping the associated bot in that case