### PR TITLE
4602 source errors not disabling: alternate fix

### DIFF
--- a/lib/fetching.js
+++ b/lib/fetching.js
@@ -1,4 +1,5 @@
 // Sets up the fetching module process and necessary event proxies.
+'use strict';
 
 process.title = 'aggie-fetching';
 
@@ -14,11 +15,16 @@ require('./error');
 
 // Initialize Bot Master and add event proxies
 var botMaster = require('./fetching/bot-master');
-botMaster.init(function(){
+botMaster.init(function() {
   botMaster.addListeners('source', childProcess.setupEventProxy({
     emitter: '/models/source',
     subclass: 'schema',
     emitterModule: 'api'
+  }));
+  botMaster.addListeners('source', childProcess.setupEventProxy({
+    emitter: '/models/source',
+    subclass: 'schema',
+    emitterModule: 'fetching'
   }));
   botMaster.addListeners('fetching', childProcess.setupEventProxy({
     emitter: '/lib/api/v1/settings-controller',
@@ -30,7 +36,7 @@ botMaster.init(function(){
 var reportWriter = require('./fetching/report-writer');
 
 // handle uncaught exceptions
-process.on('uncaughtException', function (err) {
+process.on('uncaughtException', function(err) {
   logger.error(err);
 });
 


### PR DESCRIPTION
Now `_addSourceListeners` will get called with `emitter` as the
`Source.schema` from the fetching process. This is also kind of silly
because it goes through ChildProcess unnecessarily, but it seems clean
enough.

This PR is instead of #171