### PR TITLE
Pass params to be interpolated in flash alerts

### DIFF
--- a/public/angular/js/services/flash.js
+++ b/public/angular/js/services/flash.js
@@ -11,11 +11,11 @@ angular.module('Aggie').factory('FlashService', [
 
     return {
       getAlert: function() {
-        return $translate.instant(currentFlash.alert);
+        return $translate.instant(currentFlash.alert, currentFlash.params);
       },
 
       getNotice: function() {
-        return $translate.instant(currentFlash.notice);
+        return $translate.instant(currentFlash.notice, currentFlash.params);
       },
 
       setAlert: function(message, params) {


### PR DESCRIPTION
To reproduce the bug this fixes:

1. Go to Settings > Settings
2. Click Edit in the email transport field
3. Click Submit in the modal that pops up

The notice "SES setting has been successfully saved." should appear, but
it was only saying " setting has been successfully saved."