### PR TITLE
Bugfix for change password button

### DIFF
--- a/public/angular/js/controllers/users/form_modal.js
+++ b/public/angular/js/controllers/users/form_modal.js
@@ -69,9 +69,9 @@ angular.module('Aggie')
     $scope.user = angular.copy(user);
     $scope.user.oldUserName = user.username;
     $scope.showErrors = false;
-    $scope.showPassword = false;
     $scope.passwordMinLength = shared.User.PASSWORD_MIN_LENGTH;
     $scope.message = '';
+    $scope.model = { showPassword: false };
 
     var handleSuccess = function(response) {
       $modalInstance.close(response);

--- a/public/angular/templates/users/modal.html
+++ b/public/angular/templates/users/modal.html
@@ -62,10 +62,10 @@
             </div>
           </div>
           <div ng-show="user._id == currentUser._id">
-            <div class="form-group" ng-hide="showPassword || form.password.$dirty || form.passwordConfirmation.$dirty">
-              <button type="button" class="btn col-lg-6 col-lg-offset-3" ng-click="showPassword = !showPassword" translate>Change password</button>
+            <div class="form-group" ng-hide="model.showPassword || form.password.$dirty || form.passwordConfirmation.$dirty">
+              <button type="button" class="btn col-lg-6 col-lg-offset-3" ng-click="model.showPassword = true" translate>Change password</button>
             </div>
-            <div ng-show="showPassword || form.password.$dirty || form.passwordConfirmation.$dirty">
+            <div ng-show="model.showPassword || form.password.$dirty || form.passwordConfirmation.$dirty">
               <div class="form-group">
                 <label for="password" class="col-lg-3 control-label" translate>Password</label>
                 <div class="col-lg-6">


### PR DESCRIPTION
Summary: Subtly poor coding practices from long ago became a bug when
internationalization was added.

To reproduce the bug this fixes, go to `/users`, click the pencil by
your user, and click the Change Password button. This button wasn't
doing anything.

The cause was that adding the `translate` directive to the element
creates a new child scope. When the `ng-click` directive tried to update
the `showPassword` model it was only changing on the child scope. Best
practice is for `$scope` to always hold a reference to an object that
holds the primitives that make up the model. Then the object can be
shared between parent and child scopes. See
https://github.com/angular/angular.js/wiki/Understanding-Scopes

I read through the rest of the internationalization changes and it
seems this is the only place this comes up.