### PR TITLE
Clean tests

### DIFF
--- a/lib/analytics/stats-master.js
+++ b/lib/analytics/stats-master.js
@@ -1,6 +1,6 @@
 // Watches for new reports and changes in incidents.
 // Executes throttled queries for various stats and triggers 'stats' event
-// to expose stats data to other modules. 
+// to expose stats data to other modules.
 
 var _ = require('underscore');
 var util = require('util');
@@ -42,13 +42,14 @@ StatsMaster.prototype.addListeners = function(type, emitter) {
 // Load all stats stats
 StatsMaster.prototype.countStats = function(type, callback) {
   var self = this;
+  callback = callback || function() {};
   process.nextTick(function() {
     self.statsQueryer.count(type, function(err, results) {
-      if (err) return;
+      if (err) return callback(err);
 
       _.extend(self.stats, results);
       self.emit('stats', self.stats);
-      callback && callback(err, results);
+      callback(null, results);
     });
   });
 };

--- a/test/init.js
+++ b/test/init.js
@@ -70,6 +70,27 @@ function wipeModels(models) {
 }
 module.exports.wipeModels = wipeModels;
 
+function waitForEventsToStop(emitter, eventName, timeout, callback) {
+  var x;
+
+  var start = function() {
+    setTimeout(function() {
+      x = null;
+      callback();
+    }, timeout);
+  };
+
+  start();
+
+  emitter.on(eventName, function() {
+    if (x) {
+      clearTimeout(x);
+      start();
+    }
+  });
+}
+module.exports.waitForEventsToStop = waitForEventsToStop;
+
 function removeUsersExceptAdmin(done) {
   var query = {
     username: { $ne: 'admin' }

--- a/test/init.js
+++ b/test/init.js
@@ -17,7 +17,7 @@ before(function(done) {
   database.mongoose.disconnect(function() {
     database.mongoose.connect(dbConnectURL, function() {
       // Enable database-level text search
-      database.mongoose.connections[0].db.admin().command({setParameter: 1, textSearchEnabled: true}, function(err, res) {
+      database.mongoose.connections[0].db.admin().command({ setParameter: 1, textSearchEnabled: true }, function(err, res) {
         if (err) return done(err);
         // Create admin user for testing
         User.create({

--- a/test/init.js
+++ b/test/init.js
@@ -6,7 +6,11 @@ var dbConnectURL = process.env.MONGO_CONNECTION_URL = 'mongodb://' + host + '/ag
 var database = require('../lib/database');
 var Report = require('../models/report');
 var User = require('../models/user');
+var Source = require('../models/source');
+var Trend = require('../models/trend');
+var Incident = require('../models/incident');
 var expect = require('chai').expect;
+var async = require('async');
 
 before(function(done) {
   // Change database before starting any test
@@ -16,11 +20,16 @@ before(function(done) {
       database.mongoose.connections[0].db.admin().command({setParameter: 1, textSearchEnabled: true}, function(err, res) {
         if (err) return done(err);
         // Create admin user for testing
-        User.create({provider: 'test', email: 'admin@example.com', username: 'admin', password: 'letmein1', hasDefaultPassword: true, role: 'admin'});
-        // Enable full-text indexing for Reports
-        Report.ensureIndexes(function() {
-          done();
+        User.create({
+          provider: 'test',
+          email: 'admin@example.com',
+          username: 'admin',
+          password: 'letmein1',
+          hasDefaultPassword: true,
+          role: 'admin'
         });
+        // Enable full-text indexing for Reports
+        Report.ensureIndexes(done);
       });
     });
   });
@@ -29,11 +38,45 @@ before(function(done) {
 // Drop test database after all tests are done
 after(function(done) {
   database.mongoose.connection.db.dropDatabase(function() {
-    database.mongoose.disconnect(function() {
-      done();
-    });
+    database.mongoose.disconnect(done);
   });
 });
+
+
+function expectModelsEmpty(done) {
+  User.find({}, function(err, results) {
+    if (err) return done(err);
+    expect(results).to.have.length(1);
+    async.each([Report, Source, Trend, Incident], expectEmpty, done);
+  });
+}
+module.exports = {};
+module.exports.expectModelsEmpty = expectModelsEmpty;
+
+function expectEmpty(model, done) {
+  model.find({}, function(err, results) {
+    if (err) return done(err);
+    expect(results).to.be.empty;
+    done();
+  });
+}
+
+function wipeModels(models) {
+  return function(done) {
+    async.each(models, function(model, callback) {
+      model.remove({}, callback);
+    }, done);
+  };
+}
+module.exports.wipeModels = wipeModels;
+
+function removeUsersExceptAdmin(done) {
+  var query = {
+    username: { $ne: 'admin' }
+  };
+  User.remove(query, done);
+}
+module.exports.removeUsersExceptAdmin = removeUsersExceptAdmin;
 
 // Compare object attributes
 compare = function(a, b) {
@@ -45,11 +88,12 @@ compare = function(a, b) {
 };
 
 // Expect listener to not emit reports
-expectToNotEmitReport = function(listener, done) {
-  listener.once('report', function(report_data) {
+function expectToNotEmitReport(listener, done) {
+  listener.once('report', function() {
     done(new Error('Should not emit reports'));
   });
-};
+}
+module.exports.expectToNotEmitReport = expectToNotEmitReport;
 
 // Expect listener to emit specific errors
 expectToEmitError = function(listener, message, done) {

--- a/test/init.js
+++ b/test/init.js
@@ -1,3 +1,5 @@
+'use strict';
+
 process.env.NODE_ENV = 'test';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -70,27 +72,6 @@ function wipeModels(models) {
 }
 module.exports.wipeModels = wipeModels;
 
-function waitForEventsToStop(emitter, eventName, timeout, callback) {
-  var x;
-
-  var start = function() {
-    setTimeout(function() {
-      x = null;
-      callback();
-    }, timeout);
-  };
-
-  start();
-
-  emitter.on(eventName, function() {
-    if (x) {
-      clearTimeout(x);
-      start();
-    }
-  });
-}
-module.exports.waitForEventsToStop = waitForEventsToStop;
-
 function removeUsersExceptAdmin(done) {
   var query = {
     username: { $ne: 'admin' }
@@ -100,13 +81,14 @@ function removeUsersExceptAdmin(done) {
 module.exports.removeUsersExceptAdmin = removeUsersExceptAdmin;
 
 // Compare object attributes
-compare = function(a, b) {
+function compare(a, b) {
   for (var attr in a) {
     if (b[attr]) {
       expect(a[attr]).to.equal(b[attr]);
     }
   }
-};
+}
+module.exports.compare = compare;
 
 // Expect listener to not emit reports
 function expectToNotEmitReport(listener, done) {
@@ -117,10 +99,11 @@ function expectToNotEmitReport(listener, done) {
 module.exports.expectToNotEmitReport = expectToNotEmitReport;
 
 // Expect listener to emit specific errors
-expectToEmitError = function(listener, message, done) {
+function expectToEmitError(listener, message, done) {
   listener.once('error', function(err) {
     expect(err).to.be.an.instanceof(Error);
     expect(err.message).to.contain(message);
     done();
   });
-};
+}
+module.exports.expectToEmitError = expectToEmitError;

--- a/test/lib.analytics.stats-master.test.js
+++ b/test/lib.analytics.stats-master.test.js
@@ -1,10 +1,8 @@
 var utils = require('./init');
 var expect = require('chai').expect;
 var statsMaster = require('../lib/analytics/stats-master');
-var statsQueryer = require('../lib/analytics/stats-queryer');
 var Report = require('../models/report');
 var Incident = require('../models/incident');
-var _ = require('underscore');
 var async = require('async');
 
 describe('StatsMaster', function() {
@@ -29,11 +27,13 @@ describe('StatsMaster', function() {
     statsMaster.addListeners('incident', Incident.schema);
   });
 
-  beforeEach(function (done) {
-    async.parallel([createReports, createIncidents], done);
+  beforeEach(function(done) {
+    async.parallel([createReports, createIncidents], function(err) {
+      utils.waitForEventsToStop(statsMaster, 'stats', 100, done.bind({}, err));
+    });
   });
 
-  afterEach(function (done) {
+  afterEach(function(done) {
     async.parallel([Incident.remove.bind(Incident, {}), Report.remove.bind(Report, {})], done);
   });
 
@@ -46,7 +46,7 @@ describe('StatsMaster', function() {
     expect(stats).to.have.property('totalReports');
     expect(stats.totalReports).to.equal(3);
   });
-  
+
   it('should count flagged reports', function() {
     var stats = statsMaster.stats;
     expect(stats).to.have.property('totalReportsFlagged');
@@ -101,7 +101,7 @@ describe('StatsMaster', function() {
   });
 
   it('should count only incidents', function(done) {
-    statsMaster.countStats('incidents', function (err, stats) {      
+    statsMaster.countStats('incidents', function (err, stats) {
       expect(stats.totalIncidents).to.equal(3);
       expect(stats.totalEscalatedIncidents).to.equal(1);
       expect(stats.totalReports).not.exist;

--- a/test/lib.analytics.stats-master.test.js
+++ b/test/lib.analytics.stats-master.test.js
@@ -1,9 +1,12 @@
+'use strict';
+
 var utils = require('./init');
 var expect = require('chai').expect;
 var statsMaster = require('../lib/analytics/stats-master');
 var Report = require('../models/report');
 var Incident = require('../models/incident');
 var async = require('async');
+var _ = require('lodash');
 
 describe('StatsMaster', function() {
   function createReports(done) {
@@ -29,7 +32,9 @@ describe('StatsMaster', function() {
 
   beforeEach(function(done) {
     async.parallel([createReports, createIncidents], function(err) {
-      utils.waitForEventsToStop(statsMaster, 'stats', 100, done.bind({}, err));
+      // Call done on just the third 'stats' event
+      var finished = _.after(3, _.once(done.bind({}, err)));
+      statsMaster.on('stats', finished);
     });
   });
 

--- a/test/lib.analytics.stats-master.test.js
+++ b/test/lib.analytics.stats-master.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var statsMaster = require('../lib/analytics/stats-master');
 var statsQueryer = require('../lib/analytics/stats-queryer');
@@ -108,4 +108,6 @@ describe('StatsMaster', function() {
       done();
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.analytics.stats-master.test.js
+++ b/test/lib.analytics.stats-master.test.js
@@ -8,17 +8,17 @@ var async = require('async');
 describe('StatsMaster', function() {
   function createReports(done) {
     Report.create([
-      {storedAt: new Date(), content: 'one', flagged: true},
-      {storedAt: new Date(), content: 'two', flagged: false},
-      {storedAt: new Date("2014-01-01"), content: 'three', flagged: true, read: true }
+      { storedAt: new Date(), content: 'one', flagged: true },
+      { storedAt: new Date(), content: 'two', flagged: false },
+      { storedAt: new Date('2014-01-01'), content: 'three', flagged: true, read: true }
     ], done);
   }
 
   function createIncidents(done) {
     Incident.create([
-      {title: 'Incident 1', veracity: false, escalated: false, status: 'new'},
-      {title: 'Incident 2', veracity: true, escalated: false, status: 'new'},
-      {title: 'Incident 3', veracity: true, escalated: true, status: 'new'}
+      { title: 'Incident 1', veracity: false, escalated: false, status: 'new' },
+      { title: 'Incident 2', veracity: true, escalated: false, status: 'new' },
+      { title: 'Incident 3', veracity: true, escalated: true, status: 'new' }
     ], done);
   }
 
@@ -78,7 +78,7 @@ describe('StatsMaster', function() {
   });
 
   it('should count all stats', function(done) {
-    statsMaster.countStats('all', function (err, stats) {
+    statsMaster.countStats('all', function(err, stats) {
       expect(stats.totalReports).to.equal(3);
       expect(stats.totalReportsFlagged).to.equal(2);
       expect(stats.totalReportsUnread).to.equal(2);
@@ -90,7 +90,7 @@ describe('StatsMaster', function() {
   });
 
   it('should count only reports stats', function(done) {
-    statsMaster.countStats('reports', function (err, stats) {
+    statsMaster.countStats('reports', function(err, stats) {
       expect(stats.totalReports).to.equal(3);
       expect(stats.totalReportsFlagged).to.equal(2);
       expect(stats.totalReportsUnread).to.equal(2);
@@ -101,7 +101,7 @@ describe('StatsMaster', function() {
   });
 
   it('should count only incidents', function(done) {
-    statsMaster.countStats('incidents', function (err, stats) {
+    statsMaster.countStats('incidents', function(err, stats) {
       expect(stats.totalIncidents).to.equal(3);
       expect(stats.totalEscalatedIncidents).to.equal(1);
       expect(stats.totalReports).not.exist;

--- a/test/lib.analytics.stats-queryer.test.js
+++ b/test/lib.analytics.stats-queryer.test.js
@@ -9,17 +9,17 @@ describe('StatsQueryer', function() {
 
   function createReports(done) {
     Report.create([
-      {storedAt: new Date(), content: 'one', flagged: true},
-      {storedAt: new Date(), content: 'two', flagged: false},
-      {storedAt: new Date("2014-01-01"), content: 'three', flagged: true, read: true }
+      { storedAt: new Date(), content: 'one', flagged: true },
+      { storedAt: new Date(), content: 'two', flagged: false },
+      { storedAt: new Date('2014-01-01'), content: 'three', flagged: true, read: true }
     ], done);
   }
 
   function createIncidents(done) {
     Incident.create([
-      {title: 'Incident 1', veracity: false, escalated: false, status: 'new'},
-      {title: 'Incident 2', veracity: true, escalated: false, status: 'new'},
-      {title: 'Incident 3', veracity: true, escalated: true, status: 'new'}
+      { title: 'Incident 1', veracity: false, escalated: false, status: 'new' },
+      { title: 'Incident 2', veracity: true, escalated: false, status: 'new' },
+      { title: 'Incident 3', veracity: true, escalated: true, status: 'new' }
     ], done);
   }
 
@@ -27,11 +27,11 @@ describe('StatsQueryer', function() {
     this.statsQueryer = new StatsQueryer();
   });
 
-  beforeEach(function (done) {
+  beforeEach(function(done) {
     async.parallel([createReports, createIncidents], done);
   });
 
-  afterEach(function (done) {
+  afterEach(function(done) {
     async.parallel([Incident.remove.bind(Incident, {}), Report.remove.bind(Report, {})], done);
   });
 

--- a/test/lib.analytics.stats-queryer.test.js
+++ b/test/lib.analytics.stats-queryer.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var StatsQueryer = require('../lib/analytics/stats-queryer');
 var Report = require('../models/report');
@@ -66,7 +66,7 @@ describe('StatsQueryer', function() {
       done();
     });
   });
-  
+
   it('should count reports incidents', function(done) {
     this.statsQueryer.count('incidents', function(err, stats) {
       expect(stats.totalIncidents).to.equal(3);
@@ -76,4 +76,5 @@ describe('StatsQueryer', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.analytics.trend-master.test.js
+++ b/test/lib.analytics.trend-master.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var trendMaster = require('../lib/analytics/trend-master');
 var TrendQueryer = require('../lib/analytics/trend-queryer');
@@ -179,4 +179,6 @@ describe('Trend master', function() {
       });
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.analytics.trend-master.test.js
+++ b/test/lib.analytics.trend-master.test.js
@@ -15,9 +15,9 @@ describe('Trend master', function() {
   });
 
   it('should track all trends', function(done) {
-    Trend.create({_query: ReportQuery.hash(new ReportQuery({keywords: 'one'}))});
-    Trend.create({_query: ReportQuery.hash(new ReportQuery({keywords: 'two'}))});
-    Trend.create({_query: ReportQuery.hash(new ReportQuery({keywords: 'three'}))});
+    Trend.create({ _query: ReportQuery.hash(new ReportQuery({ keywords: 'one' })) });
+    Trend.create({ _query: ReportQuery.hash(new ReportQuery({ keywords: 'two' })) });
+    Trend.create({ _query: ReportQuery.hash(new ReportQuery({ keywords: 'three' })) });
     setTimeout(function() {
       expect(trendMaster).to.have.property('trends');
       expect(trendMaster.trends).to.be.an.instanceof(Array);
@@ -46,7 +46,7 @@ describe('Trend master', function() {
   });
 
   it('should track when trends are disabled', function(done) {
-    var trendId = _.findWhere(trendMaster.trends, {enabled: true})._id;
+    var trendId = _.findWhere(trendMaster.trends, { enabled: true })._id;
     Trend.findById(trendId, function(err, trend) {
       if (err) return done(err);
       trend.toggle('disable', function(err) {
@@ -62,7 +62,7 @@ describe('Trend master', function() {
   });
 
   it('should track when trends are enabled', function(done) {
-    var trendId = _.findWhere(trendMaster.trends, {enabled: false})._id;
+    var trendId = _.findWhere(trendMaster.trends, { enabled: false })._id;
     Trend.findById(trendId, function(err, trend) {
       if (err) return done(err);
       trend.toggle('enable', function(err) {
@@ -79,14 +79,14 @@ describe('Trend master', function() {
 
   it('should trigger a trend to run a query', function(done) {
     trendMaster.disable();
-    Trend.create({_query: ReportQuery.hash(new ReportQuery({keywords: 'four'}))});
+    Trend.create({ _query: ReportQuery.hash(new ReportQuery({ keywords: 'four' })) });
     setTimeout(function() {
-      Report.create({content: 'four'});
-      Report.create({content: 'four'});
-      Report.create({content: 'four'});
-      Report.create({content: 'four'});
+      Report.create({ content: 'four' });
+      Report.create({ content: 'four' });
+      Report.create({ content: 'four' });
+      Report.create({ content: 'four' });
       setTimeout(function() {
-        var trendId = _.findWhere(trendMaster.trends, {_query: '{"keywords":"four"}'})._id;
+        var trendId = _.findWhere(trendMaster.trends, { _query: '{"keywords":"four"}' })._id;
         trendMaster.enable();
         trendMaster.query(trendId, function(err, trends, trend) {
           if (err) return done(err);
@@ -110,18 +110,18 @@ describe('Trend master', function() {
         done();
       }
     });
-    Report.create({content: 'one'});
-    Report.create({content: 'two'});
-    Report.create({content: 'three'});
+    Report.create({ content: 'one' });
+    Report.create({ content: 'two' });
+    Report.create({ content: 'three' });
     setTimeout(function() {
-      Report.create({content: 'one'});
-      Report.create({content: 'two'});
-      Report.create({content: 'three'});
+      Report.create({ content: 'one' });
+      Report.create({ content: 'two' });
+      Report.create({ content: 'three' });
     }, 200);
     setTimeout(function() {
-      Report.create({content: 'one'});
-      Report.create({content: 'two'});
-      Report.create({content: 'three'});
+      Report.create({ content: 'one' });
+      Report.create({ content: 'two' });
+      Report.create({ content: 'three' });
     }, 300);
   });
 
@@ -141,16 +141,16 @@ describe('Trend master', function() {
       }
     });
     // Create a new trend while queries are running
-    Trend.create({_query: ReportQuery.hash(new ReportQuery({keywords: 'five'}))}, function(err, trend) {
+    Trend.create({ _query: ReportQuery.hash(new ReportQuery({ keywords: 'five' })) }, function(err, trend) {
       if (err) return done(err);
     });
-    Report.create({content: 'one'});
-    Report.create({content: 'two'});
-    Report.create({content: 'three'});
-    Report.create({content: 'four'});
+    Report.create({ content: 'one' });
+    Report.create({ content: 'two' });
+    Report.create({ content: 'three' });
+    Report.create({ content: 'four' });
     // Create a report for the new trend to capture
     setTimeout(function() {
-      Report.create({content: 'five'}, function(err, report) {
+      Report.create({ content: 'five' }, function(err, report) {
         if (err) return done(err);
       });
     }, 200);

--- a/test/lib.analytics.trend-queryer.test.js
+++ b/test/lib.analytics.trend-queryer.test.js
@@ -11,9 +11,9 @@ var _ = require('underscore');
 var trendQueryer;
 describe('Trend queryer', function() {
   before(function(done) {
-    Trend.create({_query: Query.hash(new ReportQuery({keywords: 'test'}))}, function(err, trend) {
+    Trend.create({ _query: Query.hash(new ReportQuery({ keywords: 'test' })) }, function(err, trend) {
       if (err) return done(err);
-      trendQueryer = new TrendQueryer({trend: trend});
+      trendQueryer = new TrendQueryer({ trend: trend });
       done();
     });
   });
@@ -32,11 +32,11 @@ describe('Trend queryer', function() {
   });
 
   it('should run query associated with trend', function(done) {
-    Report.create({content: 'test'});
-    Report.create({content: 'testing this'});
-    Report.create({content: 'but not this'});
-    Report.create({content: 'this should also be tested'});
-    Report.create({content: 'but this one should not'});
+    Report.create({ content: 'test' });
+    Report.create({ content: 'testing this' });
+    Report.create({ content: 'but not this' });
+    Report.create({ content: 'this should also be tested' });
+    Report.create({ content: 'but this one should not' });
     setTimeout(function() {
       trendQueryer.runQuery(function(err, counts) {
         if (err) return done(err);
@@ -52,12 +52,12 @@ describe('Trend queryer', function() {
   });
 
   it('should run query without keywords', function(done) {
-    Trend.create({_query: Query.hash(new ReportQuery({media: 'test', since: 1}))}, function(err, trend) {
+    Trend.create({ _query: Query.hash(new ReportQuery({ media: 'test', since: 1 })) }, function(err, trend) {
       if (err) return done(err);
-      trendQueryer = new TrendQueryer({trend: trend});
+      trendQueryer = new TrendQueryer({ trend: trend });
       setTimeout(function() {
-        Report.create({content: 'foo', _media: 'bar'});
-        Report.create({content: 'baz', _media: 'test'});
+        Report.create({ content: 'foo', _media: 'bar' });
+        Report.create({ content: 'baz', _media: 'test' });
         setTimeout(function() {
           trendQueryer.runQuery(function(err, counts) {
             if (err) return done(err);
@@ -73,26 +73,26 @@ describe('Trend queryer', function() {
   });
 
   it('should group analytics by 5-minute timeboxes', function(done) {
-    Trend.create({_query: Query.hash(new ReportQuery({keywords: 'qwerty'}))}, function(err, trend) {
+    Trend.create({ _query: Query.hash(new ReportQuery({ keywords: 'qwerty' })) }, function(err, trend) {
       setTimeout(function() {
         if (err) return done(err);
-        trendQueryer = new TrendQueryer({trend: trend});
+        trendQueryer = new TrendQueryer({ trend: trend });
 
         // Create one report now
-        Report.create({content: 'qwerty'});
+        Report.create({ content: 'qwerty' });
 
         process.nextTick(function() {
           // Create two reports 5 minutes in the future
           timekeeper.travel(new Date(Date.now() + 300000));
-          Report.create({content: 'qwerty'});
-          Report.create({content: 'qwerty'});
+          Report.create({ content: 'qwerty' });
+          Report.create({ content: 'qwerty' });
 
           process.nextTick(function() {
             // Create three reports 10 minutes in the future
             timekeeper.travel(new Date(Date.now() + 600000));
-            Report.create({content: 'qwerty'});
-            Report.create({content: 'qwerty'});
-            Report.create({content: 'qwerty'});
+            Report.create({ content: 'qwerty' });
+            Report.create({ content: 'qwerty' });
+            Report.create({ content: 'qwerty' });
 
             setTimeout(function() {
               // Run trend analytics
@@ -116,21 +116,21 @@ describe('Trend queryer', function() {
 
   it('should back-fill trend counts for old reports', function(done) {
     // Create reports
-    Report.create({content: 'backfill'});
-    Report.create({content: 'backfill'});
-    Report.create({content: 'backfill'});
+    Report.create({ content: 'backfill' });
+    Report.create({ content: 'backfill' });
+    Report.create({ content: 'backfill' });
     process.nextTick(function() {
       // Travel 10 minutes into the future
       timekeeper.travel(new Date(Date.now() + 300000));
-      Report.create({content: 'backfill'});
-      Report.create({content: 'backfill'});
+      Report.create({ content: 'backfill' });
+      Report.create({ content: 'backfill' });
       process.nextTick(function() {
         // Travel 10 minutes into the future
         timekeeper.travel(new Date(Date.now() + 600000));
         // Create a new trend
-        Trend.create({_query: Query.hash(new ReportQuery({keywords: 'backfill'}))}, function(err, trend) {
+        Trend.create({ _query: Query.hash(new ReportQuery({ keywords: 'backfill' })) }, function(err, trend) {
           if (err) return done(err);
-          trendQueryer = new TrendQueryer({trend: trend});
+          trendQueryer = new TrendQueryer({ trend: trend });
           trendQueryer.backFill(function(err, counts) {
             if (err) return done(err);
             counts = _.sortBy(counts, 'timebox');

--- a/test/lib.analytics.trend-queryer.test.js
+++ b/test/lib.analytics.trend-queryer.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var TrendQueryer = require('../lib/analytics/trend-queryer');
 var Trend = require('../models/trend');
@@ -148,13 +148,6 @@ describe('Trend queryer', function() {
   });
 
   // Clean up
-  after(function(done) {
-    Trend.remove(function(err) {
-      if (err) return done(err);
-      Report.remove(function(err) {
-        if (err) return done(err);
-        done();
-      });
-    });
-  });
+  after(utils.wipeModels([Trend, Report]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.language-cookie.test.js
+++ b/test/lib.api.language-cookie.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var express = require('express');
@@ -19,6 +19,7 @@ describe('Language cookie', function() {
       .expect(200)
       .expect('set-cookie', 'aggie-lang=en; Path=/', done);
   });
+
   it('should pick the best language', function(done) {
     request(app)
       .get('/reports')
@@ -26,4 +27,6 @@ describe('Language cookie', function() {
       .expect(200)
       .expect('set-cookie', 'aggie-lang=es; Path=/', done);
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.socket-handler.test.js
+++ b/test/lib.api.socket-handler.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var SocketHandler = require('../lib/api/socket-handler');
 var streamer = require('../lib/api/streamer');
@@ -126,4 +126,8 @@ describe('Socket handler', function() {
   after(function(done) {
     socketHandler.server.close(done);
   });
+
+  // Clean up the database
+  after(utils.wipeModels([Report, Incident, Source]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.socket-handler.test.js
+++ b/test/lib.api.socket-handler.test.js
@@ -14,7 +14,7 @@ var https = require('https');
 var path = require('path');
 var fs = require('fs');
 
-function createServer(app){
+function createServer(app) {
   // Get full path for certificate files
   var keyFile = path.resolve(__dirname, '../config/key.pem');
   var certFile = path.resolve(__dirname, '../config/cert.pem');
@@ -54,7 +54,7 @@ describe('Socket handler', function() {
   });
 
   it('should establish connections with a query', function(done) {
-    client.emit('query', {keywords: 'test'});
+    client.emit('query', { keywords: 'test' });
     setTimeout(function() {
       expect(streamer.queries).to.be.an.instanceof(Array);
       expect(streamer.queries).to.not.be.empty;
@@ -73,14 +73,14 @@ describe('Socket handler', function() {
       expect(reports[2].content.toLowerCase()).to.contain('test');
       done();
     });
-    Report.create({content: 'This is a test'});
-    Report.create({content: 'This is another TEST'});
-    Report.create({content: 'Testing this'});
-    Report.create({content: 'one two three'});
+    Report.create({ content: 'This is a test' });
+    Report.create({ content: 'This is another TEST' });
+    Report.create({ content: 'Testing this' });
+    Report.create({ content: 'one two three' });
   });
 
   it('should establish connections with an incident query', function(done) {
-    client.emit('incidentQuery', {title: 'quick brown'});
+    client.emit('incidentQuery', { title: 'quick brown' });
     setTimeout(function() {
       expect(streamer.queries).to.be.an.instanceof(Array);
       expect(streamer.queries).to.not.be.empty;
@@ -98,8 +98,8 @@ describe('Socket handler', function() {
       expect(incidents[0].title).to.equal('The quick brown fox');
       done();
     });
-    Incident.create({title: 'The slow white fox'});
-    Incident.create({title: 'The quick brown fox'});
+    Incident.create({ title: 'The slow white fox' });
+    Incident.create({ title: 'The quick brown fox' });
   });
 
   it('should stream a list of sources when a source changes', function(done) {
@@ -109,7 +109,7 @@ describe('Socket handler', function() {
       expect(sources[0]).to.contain.keys(['_id', 'nickname', 'unreadErrorCount', 'enabled', '__v']);
       done();
     });
-    Source.create({nickname: 'test', type: 'dummy'});
+    Source.create({ nickname: 'test', type: 'dummy' });
   });
 
   // Disconnect socket

--- a/test/lib.api.streamer.test.js
+++ b/test/lib.api.streamer.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var streamer = require('../lib/api/streamer');
 var ReportQuery = require('../models/query/report-query');
@@ -56,4 +56,7 @@ describe('Streamer', function() {
       done();
     });
   });
+
+  after(utils.wipeModels([Report]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.streamer.test.js
+++ b/test/lib.api.streamer.test.js
@@ -7,16 +7,16 @@ var Report = require('../models/report');
 describe('Streamer', function() {
   before(function(done) {
     streamer.queries = [];
-    Report.create({content: '1 one'});
-    Report.create({content: '2 two'});
-    Report.create({content: 'One one'});
-    Report.create({content: 'Two two'});
+    Report.create({ content: '1 one' });
+    Report.create({ content: '2 two' });
+    Report.create({ content: 'One one' });
+    Report.create({ content: 'Two two' });
     setTimeout(done, 500);
   });
 
   it('should track Query objects', function(done) {
-    var queryOne = new ReportQuery({keywords: 'one'});
-    var queryTwo = new ReportQuery({keywords: 'two'});
+    var queryOne = new ReportQuery({ keywords: 'one' });
+    var queryTwo = new ReportQuery({ keywords: 'two' });
     streamer.addQuery(queryOne);
     streamer.addQuery(queryTwo);
     expect(streamer.queries).to.be.an.instanceof(Array);
@@ -41,12 +41,12 @@ describe('Streamer', function() {
 
   it('should listen to new reports and re-start query', function(done) {
     streamer.queries = [];
-    var queryThree = new ReportQuery({keywords: 'three'});
+    var queryThree = new ReportQuery({ keywords: 'three' });
     streamer.addQuery(queryThree);
     streamer.addListeners('report', Report.schema);
     process.nextTick(function() {
-      Report.create({content: '3 three'});
-      Report.create({content: 'Three three'});
+      Report.create({ content: '3 three' });
+      Report.create({ content: 'Three three' });
     });
     streamer.once('reports', function(query, reports) {
       expect(reports).to.be.an.instanceof(Array);

--- a/test/lib.api.v1.incident-controller.test.js
+++ b/test/lib.api.v1.incident-controller.test.js
@@ -7,7 +7,7 @@ var incidentController = require('../lib/api/v1/incident-controller')();
 var incident;
 describe('Incident controller', function() {
   before(function(done) {
-    incident = {title: 'test'};
+    incident = { title: 'test' };
     done();
   });
 
@@ -59,7 +59,7 @@ describe('Incident controller', function() {
     it('should whitelist status values', function(done) {
       request(incidentController)
         .put('/api/v1/incident/' + incident._id)
-        .send({status: 'undefined'})
+        .send({ status: 'undefined' })
         .expect(422, 'status_error', done);
     });
   });
@@ -74,7 +74,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.keys(['total', 'results']);
           expect(res.body.results).to.be.an.instanceof(Array);
           expect(res.body.results).to.not.be.empty;
-          compare(_.findWhere(res.body.results, {_id: incident._id}), incident);
+          compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
           done();
         });
     });
@@ -87,7 +87,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.keys(['total', 'results']);
           expect(res.body.results).to.be.an.instanceof(Array);
           expect(res.body.results).to.not.be.empty;
-          compare(_.findWhere(res.body.results, {_id: incident._id}), incident);
+          compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
           done();
         });
     });
@@ -127,7 +127,7 @@ describe('Incident controller', function() {
         .end(function(err, res) {
           request(incidentController)
             .get('/api/v1/incident')
-            .expect(200, {total: 0, results: []}, done);
+            .expect(200, { total: 0, results: [] }, done);
         });
     });
   });
@@ -136,12 +136,12 @@ describe('Incident controller', function() {
     it('should delete all incidents', function(done) {
       request(incidentController)
         .post('/api/v1/incident/_selected')
-        .send({ids: [incident._id]})
+        .send({ ids: [incident._id] })
         .expect(200)
         .end(function(err, res) {
           request(incidentController)
             .get('/api/v1/incident')
-            .expect(200, {total: 0, results: []}, done);
+            .expect(200, { total: 0, results: [] }, done);
         });
     });
   });

--- a/test/lib.api.v1.incident-controller.test.js
+++ b/test/lib.api.v1.incident-controller.test.js
@@ -1,9 +1,8 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var _ = require('underscore');
 var incidentController = require('../lib/api/v1/incident-controller')();
-var Incident = require('../models/incident');
 
 var incident;
 describe('Incident controller', function() {
@@ -146,4 +145,6 @@ describe('Incident controller', function() {
         });
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.incident-controller.test.js
+++ b/test/lib.api.v1.incident-controller.test.js
@@ -24,7 +24,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.property('status');
           expect(res.body).to.have.property('veracity');
           incident._id = res.body._id;
-          compare.call(this, res.body, incident);
+          utils.compare(res.body, incident);
           done();
         });
     });
@@ -37,7 +37,7 @@ describe('Incident controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          compare.call(this, res.body, incident);
+          utils.compare(res.body, incident);
           done();
         });
     });
@@ -52,7 +52,7 @@ describe('Incident controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          compare.call(this, res.body, incident);
+          utils.compare(res.body, incident);
           done();
         });
     });
@@ -74,7 +74,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.keys(['total', 'results']);
           expect(res.body.results).to.be.an.instanceof(Array);
           expect(res.body.results).to.not.be.empty;
-          compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
+          utils.compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
           done();
         });
     });
@@ -87,7 +87,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.keys(['total', 'results']);
           expect(res.body.results).to.be.an.instanceof(Array);
           expect(res.body.results).to.not.be.empty;
-          compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
+          utils.compare(_.findWhere(res.body.results, { _id: incident._id }), incident);
           done();
         });
     });

--- a/test/lib.api.v1.report-controller.test.js
+++ b/test/lib.api.v1.report-controller.test.js
@@ -16,7 +16,7 @@ var incidents;
 
 describe('Report controller', function() {
   function createSource(done) {
-    Source.create({nickname: 'test', media: 'dummy', keywords: 'e'}, function (err, src) {
+    Source.create({ nickname: 'test', media: 'dummy', keywords: 'e' }, function(err, src) {
       source = src;
       done();
     });
@@ -31,16 +31,16 @@ describe('Report controller', function() {
 
   function createReports(done) {
     Report.create([
-      {authoredAt: new Date(), content: 'one', _source: source._id, checkedOutBy: user.id},
-      {authoredAt: new Date(), content: 'two', _source: source._id, checkedOutBy: user.id},
-      {authoredAt: new Date(), content: 'three', _source: source._id, checkedOutBy: user.id}
+      { authoredAt: new Date(), content: 'one', _source: source._id, checkedOutBy: user.id },
+      { authoredAt: new Date(), content: 'two', _source: source._id, checkedOutBy: user.id },
+      { authoredAt: new Date(), content: 'three', _source: source._id, checkedOutBy: user.id }
     ], done);
   }
 
   function createIncidents(done) {
     Incident.create([
-      { authoredAt: new Date(), title: 'First incident'},
-      { authoredAt: new Date(), title: 'Second incident'}
+      { authoredAt: new Date(), title: 'First incident' },
+      { authoredAt: new Date(), title: 'Second incident' }
     ], done);
   }
 
@@ -69,10 +69,10 @@ describe('Report controller', function() {
     beforeEach(function(done) {
       var past = new Date(2000, 1, 1, 12, 0, 0); // Feb 1
       Report.create([
-        {authoredAt: new Date(), content: 'one', flagged: true, _source: source._id},
-        {authoredAt: new Date(), content: 'one', _source: source._id},
-        {authoredAt: new Date(), content: 'two', _source: source._id},
-        {storedAt: past, authoredAt: past, content: 'three', _source: source._id}
+        { authoredAt: new Date(), content: 'one', flagged: true, _source: source._id },
+        { authoredAt: new Date(), content: 'one', _source: source._id },
+        { authoredAt: new Date(), content: 'two', _source: source._id },
+        { storedAt: past, authoredAt: past, content: 'three', _source: source._id }
       ], function() { done(); });
     });
 
@@ -130,7 +130,7 @@ describe('Report controller', function() {
 
     it('should filter by date range', function(done) {
       request(reportController)
-        .get('/api/v1/report?after=' + new Date(2000,0,31,12,0,0) + '&before=' + new Date(2000,1,2,12,0,0))
+        .get('/api/v1/report?after=' + new Date(2000, 0, 31, 12, 0, 0) + '&before=' + new Date(2000, 1, 2, 12, 0, 0))
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
@@ -144,8 +144,8 @@ describe('Report controller', function() {
   describe('DELETE /api/v1/report/_all', function() {
     beforeEach(function(done) {
       Report.create([
-        {authoredAt: new Date(), content: 'one', _source: source._id},
-        {authoredAt: new Date(), content: 'two', _source: source._id}
+        { authoredAt: new Date(), content: 'one', _source: source._id },
+        { authoredAt: new Date(), content: 'two', _source: source._id }
       ], function() { done(); });
     });
 
@@ -157,7 +157,7 @@ describe('Report controller', function() {
           if (err) return done(err);
           request(reportController)
             .get('/api/v1/report')
-            .expect(200, {total: 0, results: []}, done);
+            .expect(200, { total: 0, results: [] }, done);
         });
     });
   });
@@ -170,7 +170,7 @@ describe('Report controller', function() {
     it('should mark reports as read', function(done) {
       request(reportController)
         .patch('/api/v1/report/_read')
-        .send({ids: [reports[0].id, reports[1].id], read: true})
+        .send({ ids: [reports[0].id, reports[1].id], read: true })
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);

--- a/test/lib.api.v1.report-controller.test.js
+++ b/test/lib.api.v1.report-controller.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 require('../lib/database');
@@ -23,9 +23,9 @@ describe('Report controller', function() {
   }
 
   function loadUser(done) {
-    User.findOne({}, function (err, u) {
+    User.findOne({}, function(err, u) {
       user = u;
-      done();
+      done(err);
     });
   }
 
@@ -59,13 +59,9 @@ describe('Report controller', function() {
   }
 
 
-  beforeEach(function(done) {
-    createSource(done);
-  });
+  beforeEach(createSource);
 
-  afterEach(function(done) {
-    async.parallel([Report.remove.bind(Report, {}), Source.remove.bind(Source, {}), Incident.remove.bind(Incident, {})], done);
-  });
+  afterEach(utils.wipeModels([Report, Source, Incident]));
 
   describe('GET /api/v1/report', function() {
 
@@ -239,4 +235,6 @@ describe('Report controller', function() {
         });
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.settings-controller.test.js
+++ b/test/lib.api.v1.settings-controller.test.js
@@ -4,6 +4,7 @@ var request = require('supertest');
 var settingsController = require('../lib/api/v1/settings-controller');
 var botMaster = require('../lib/fetching/bot-master');
 var Source = require('../models/source');
+var Report = require('../models/report');
 var config = require('../config/secrets');
 var _ = require('underscore');
 
@@ -197,5 +198,9 @@ describe('Settings controller', function() {
     });
   });
 
+  // We have to delete reports here for a very sneaky reason, because when other
+  // tests are present the bots can save reports (see comment in
+  // test/lib.fetching.bot-master.test.js).
+  after(utils.wipeModels([Report]));
   after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.settings-controller.test.js
+++ b/test/lib.api.v1.settings-controller.test.js
@@ -11,16 +11,16 @@ var _ = require('underscore');
 describe('Settings controller', function() {
   before(function(done) {
     config.update('dummy', { set: 'initialDummySetting' }, function(err) {
-      Source.create({nickname: 'one', media: 'dummy', keywords: 'one'});
-      Source.create({nickname: 'two', media: 'dummy', keywords: 'two'});
-      Source.create({nickname: 'three', media: 'dummy', keywords: 'three'});
+      Source.create({ nickname: 'one', media: 'dummy', keywords: 'one' });
+      Source.create({ nickname: 'two', media: 'dummy', keywords: 'two' });
+      Source.create({ nickname: 'three', media: 'dummy', keywords: 'three' });
     });
 
     botMaster.kill();
     botMaster.addListeners('source', Source.schema);
     botMaster.addListeners('fetching', settingsController);
 
-    twitterSettings =  _.clone(config.get().twitter);
+    twitterSettings = _.clone(config.get().twitter);
 
     testSettings = {
       consumer_key: 'testing',
@@ -43,7 +43,7 @@ describe('Settings controller', function() {
     it('should return the settings JSON of twitter', function(done) {
       request(settingsController)
         .get('/api/v1/settings/twitter')
-        .expect(200, {twitter: config.get({ reload: true }).twitter, setting: 'twitter' }, done);
+        .expect(200, { twitter: config.get({ reload: true }).twitter, setting: 'twitter' }, done);
     });
   });
 
@@ -104,7 +104,7 @@ describe('Settings controller', function() {
 //    originalDummyBot;
 //    newDummyBot;
 
-    before(function(done){
+    before(function(done) {
       newSettings = { set: 'dummySetting' };
       botStatus = botMaster.bots[0].enabled;
       request(settingsController)
@@ -140,7 +140,7 @@ describe('Settings controller', function() {
     it('should return fetching status as disabled', function(done) {
       request(settingsController)
         .get('/api/v1/settings/fetching')
-        .expect(200, {fetching: false, setting: 'fetching' }, done);
+        .expect(200, { fetching: false, setting: 'fetching' }, done);
     });
   });
 
@@ -167,7 +167,7 @@ describe('Settings controller', function() {
     it('should return fetching status as enabled', function(done) {
       request(settingsController)
         .get('/api/v1/settings/fetching')
-        .expect(200, {fetching: true, setting: 'fetching'}, done);
+        .expect(200, { fetching: true, setting: 'fetching' }, done);
     });
   });
 
@@ -194,7 +194,7 @@ describe('Settings controller', function() {
     it('should return fetching status as disabled', function(done) {
       request(settingsController)
         .get('/api/v1/settings/fetching')
-        .expect(200, {fetching: false, setting: 'fetching'}, done);
+        .expect(200, { fetching: false, setting: 'fetching' }, done);
     });
   });
 

--- a/test/lib.api.v1.settings-controller.test.js
+++ b/test/lib.api.v1.settings-controller.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var settingsController = require('../lib/api/v1/settings-controller');
@@ -197,4 +197,5 @@ describe('Settings controller', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.source-controller.test.js
+++ b/test/lib.api.v1.source-controller.test.js
@@ -32,7 +32,7 @@ describe('Source controller', function() {
     it('should not allow the creation of multiple twitter sources', function(done) {
       request(sourceController)
         .post('/api/v1/source')
-        .send({nickname: 'test', media: 'twitter', keywords: 'test2'})
+        .send({ nickname: 'test', media: 'twitter', keywords: 'test2' })
         .expect(422, 'only_one_twitter_allowed', done);
     });
   });
@@ -60,7 +60,7 @@ describe('Source controller', function() {
             .end(function(err, res) {
               if (err) return done(err);
               expect(res.body).to.have.property('events');
-              expect(res.body).to.have.property('unreadErrorCount')
+              expect(res.body).to.have.property('unreadErrorCount');
               expect(res.body.events).to.be.an.instanceof(Array);
               expect(res.body.unreadErrorCount).to.equal(1);
               source.events = res.body.events;
@@ -88,7 +88,7 @@ describe('Source controller', function() {
     it('should not allow updating source media', function(done) {
       request(sourceController)
         .put('/api/v1/source/' + source._id)
-        .send({media: 'dummy'})
+        .send({ media: 'dummy' })
         .expect(422, 'source_media_change_not_allowed', done);
     });
   });
@@ -129,7 +129,7 @@ describe('Source controller', function() {
           if (err) return done(err);
           expect(res.body).to.be.an.instanceof(Array);
           expect(res.body).to.not.be.empty;
-          compare(_.findWhere(res.body, {_id: source._id}), source);
+          compare(_.findWhere(res.body, { _id: source._id }), source);
           done();
         });
     });

--- a/test/lib.api.v1.source-controller.test.js
+++ b/test/lib.api.v1.source-controller.test.js
@@ -6,6 +6,8 @@ var sourceController = require('../lib/api/v1/source-controller')();
 var Source = require('../models/source');
 
 describe('Source controller', function() {
+  var source;
+
   before(function(done) {
     source = {
       nickname: 'test',
@@ -25,7 +27,7 @@ describe('Source controller', function() {
           if (err) return done(err);
           expect(res.body).to.have.property('_id');
           source._id = res.body._id;
-          compare.call(this, res.body, source);
+          utils.compare(res.body, source);
           done();
         });
     });
@@ -44,7 +46,7 @@ describe('Source controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          compare.call(this, res.body, source);
+          utils.compare(res.body, source);
           done();
         });
     });
@@ -81,7 +83,7 @@ describe('Source controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          compare.call(this, res.body, source);
+          utils.compare(res.body, source);
           done();
         });
     });
@@ -129,7 +131,7 @@ describe('Source controller', function() {
           if (err) return done(err);
           expect(res.body).to.be.an.instanceof(Array);
           expect(res.body).to.not.be.empty;
-          compare(_.findWhere(res.body, { _id: source._id }), source);
+          utils.compare(_.findWhere(res.body, { _id: source._id }), source);
           done();
         });
     });

--- a/test/lib.api.v1.source-controller.test.js
+++ b/test/lib.api.v1.source-controller.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var _ = require('underscore');
@@ -161,4 +161,5 @@ describe('Source controller', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.source-facebook-controller.test.js
+++ b/test/lib.api.v1.source-facebook-controller.test.js
@@ -1,8 +1,11 @@
-require('./init');
+'use strict';
+
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var _ = require('underscore');
 var sourceController = require('../lib/api/v1/source-controller')();
+var Source = require('../models/source');
 
 describe('Facebook source controller', function() {
   describe('POST /api/v1/source', function() {
@@ -39,4 +42,7 @@ describe('Facebook source controller', function() {
       });
     });
   });
+
+  after(utils.wipeModels([Source]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.source-facebook-controller.test.js
+++ b/test/lib.api.v1.source-facebook-controller.test.js
@@ -36,7 +36,7 @@ describe('Facebook source controller', function() {
             if (err) return done(err);
             expect(res.body).to.have.property('_id');
             source._id = res.body._id;
-            compare.call(this, res.body, source);
+            utils.compare(res.body, source);
             done();
           });
       });

--- a/test/lib.api.v1.trend-controller.test.js
+++ b/test/lib.api.v1.trend-controller.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var _ = require('underscore');
@@ -124,4 +124,5 @@ describe('Trend controller', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.api.v1.trend-controller.test.js
+++ b/test/lib.api.v1.trend-controller.test.js
@@ -26,7 +26,7 @@ describe('Trend controller', function() {
           expect(res.body).to.have.property('_query');
           trend._id = res.body._id;
           trend._query = res.body._query;
-          compare.call(this, res.body, trend);
+          utils.compare(res.body, trend);
           done();
         });
     });
@@ -39,7 +39,7 @@ describe('Trend controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          compare.call(this, res.body, trend);
+          utils.compare(res.body, trend);
           done();
         });
     });
@@ -59,7 +59,7 @@ describe('Trend controller', function() {
             if (err) return done(err);
             expect(res.body).to.be.an.instanceof(Array);
             expect(res.body).to.have.length(4);
-            compare(_.findWhere(res.body, { _id: trend._id }), trend);
+            utils.compare(_.findWhere(res.body, { _id: trend._id }), trend);
             done();
           });
       }, 100);

--- a/test/lib.api.v1.trend-controller.test.js
+++ b/test/lib.api.v1.trend-controller.test.js
@@ -10,7 +10,7 @@ var ReportQuery = require('../models/query/report-query');
 var trend;
 describe('Trend controller', function() {
   before(function(done) {
-    trend = {keywords: 'test'};
+    trend = { keywords: 'test' };
     done();
   });
 
@@ -48,9 +48,9 @@ describe('Trend controller', function() {
   describe('GET /api/v1/trend', function() {
     it('should get a list of all trends', function(done) {
       // Add an additional 3 trends
-      Trend.create({_query: Query.hash(new ReportQuery({keywords: '123'}))});
-      Trend.create({_query: Query.hash(new ReportQuery({keywords: '456'}))});
-      Trend.create({_query: Query.hash(new ReportQuery({keywords: '789'}))});
+      Trend.create({ _query: Query.hash(new ReportQuery({ keywords: '123' })) });
+      Trend.create({ _query: Query.hash(new ReportQuery({ keywords: '456' })) });
+      Trend.create({ _query: Query.hash(new ReportQuery({ keywords: '789' })) });
       setTimeout(function() {
         request(trendController)
           .get('/api/v1/trend')
@@ -59,7 +59,7 @@ describe('Trend controller', function() {
             if (err) return done(err);
             expect(res.body).to.be.an.instanceof(Array);
             expect(res.body).to.have.length(4);
-            compare(_.findWhere(res.body, {_id: trend._id}), trend);
+            compare(_.findWhere(res.body, { _id: trend._id }), trend);
             done();
           });
       }, 100);

--- a/test/lib.api.v1.user-controller.test.js
+++ b/test/lib.api.v1.user-controller.test.js
@@ -9,8 +9,8 @@ describe('User controller', function() {
   // Create some users.
   beforeEach(function(done) {
     User.create([
-      {provider: 'test', email: 'foo@example.com', username: 'foo', password: 'letmein2'},
-      {provider: 'test', email: 'bar@example.com', username: 'bar', password: 'letmein3'}
+      { provider: 'test', email: 'foo@example.com', username: 'foo', password: 'letmein2' },
+      { provider: 'test', email: 'bar@example.com', username: 'bar', password: 'letmein3' }
     ], function(err, u1, u2) {
       users = [u1, u2];
       done(err);
@@ -54,16 +54,16 @@ describe('User controller', function() {
     it('should create a new user', function(done) {
       request(userController)
         .post('/api/v1/user')
-        .send({provider: 'test', email: 'baz@example.com', username: 'baz', password: 'letmein4'})
+        .send({ provider: 'test', email: 'baz@example.com', username: 'baz', password: 'letmein4' })
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
           expect(res.body).to.have.property('_id');
           expect(res.body.username).to.equal('baz');
-          User.where({username: 'baz'}).count(function(err, c) {
+          User.where({ username: 'baz' }).count(function(err, c) {
             expect(c).to.equal(1);
             done();
-          })
+          });
         });
     });
   });
@@ -72,15 +72,15 @@ describe('User controller', function() {
     it('should update user', function(done) {
       request(userController)
         .put('/api/v1/user/' + users[0]._id)
-        .send({email: 'updated@example.com'})
+        .send({ email: 'updated@example.com' })
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
           expect(res.body.email).to.equal('updated@example.com');
-          User.where({email: 'updated@example.com'}).count(function(err, c) {
+          User.where({ email: 'updated@example.com' }).count(function(err, c) {
             expect(c).to.equal(1);
             done();
-          })
+          });
         });
     });
   });

--- a/test/lib.api.v1.user-controller.test.js
+++ b/test/lib.api.v1.user-controller.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var request = require('supertest');
 var userController = require('../lib/api/v1/user-controller')();
@@ -6,12 +6,6 @@ var User = require('../models/user');
 var users;
 
 describe('User controller', function() {
-
-  // Clearing the db should eventually move to a global afterEach, but for now it's here else we'd break existing tests.
-  beforeEach(function(done){
-    User.remove({}, function(err){ done(err); });
-  });
-
   // Create some users.
   beforeEach(function(done) {
     User.create([
@@ -23,6 +17,10 @@ describe('User controller', function() {
     });
   });
 
+  // Clearing the db should eventually move to a global afterEach, but for now
+  // it's here else we'd break existing tests.
+  afterEach(utils.removeUsersExceptAdmin);
+
   describe('GET /api/v1/user', function() {
     it('should get a list of all users', function(done) {
       request(userController)
@@ -30,8 +28,9 @@ describe('User controller', function() {
         .expect(200)
         .end(function(err, res) {
           if (err) return done(err);
-          expect(res.body.length).to.equal(2);
-          expect(res.body[0].username).to.equal('foo');
+          // The admin user is always around, so 2+1=3
+          expect(res.body.length).to.equal(3);
+          expect(res.body[1].username).to.equal('foo');
           done();
         });
     });
@@ -104,4 +103,5 @@ describe('User controller', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.bot-master.test.js
+++ b/test/lib.fetching.bot-master.test.js
@@ -1,10 +1,11 @@
 var utils = require('./init');
 var expect = require('chai').expect;
 var botMaster = require('../lib/fetching/bot-master');
-var Bot = require('../lib/fetching/bot');
+var Report = require('../models/report');
 var Source = require('../models/source');
 
 describe('BotMaster', function() {
+  before(utils.expectModelsEmpty);
 
   before(function(done){
     Source.remove({}, function(){
@@ -78,6 +79,15 @@ describe('BotMaster', function() {
     done();
   });
 
-  after(utils.wipeModels([Source]));
+  // We have to remove all the reports here for a very sneaky reason. If you run
+  // this test file alone, there's no problem; no reports get created. But when
+  // you use mocha to run this file and one which imports
+  // '../lib/fetching/report-writer', the bots will start adding reports to the
+  // queue and they'll get saved. With enough latency, this call actually won't
+  // be enough to stop these reports from interacting with other tests, as
+  // this test file could exit with reports still in the queue. The moral is
+  // probably that sharing state with `require` statements isn't very good for
+  // modular testing.
+  after(utils.wipeModels([Source, Report]));
   after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.bot-master.test.js
+++ b/test/lib.fetching.bot-master.test.js
@@ -7,12 +7,12 @@ var Source = require('../models/source');
 describe('BotMaster', function() {
   before(utils.expectModelsEmpty);
 
-  before(function(done){
-    Source.remove({}, function(){
+  before(function(done) {
+    Source.remove({}, function() {
       Source.create(
-        {nickname: 'one', media: 'dummy', keywords: 'one'},
-        {nickname: 'two', media: 'dummy', keywords: 'two'},
-        function(err){ done(err); }
+        { nickname: 'one', media: 'dummy', keywords: 'one' },
+        { nickname: 'two', media: 'dummy', keywords: 'two' },
+        function(err) { done(err); }
       );
     });
   });
@@ -38,7 +38,7 @@ describe('BotMaster', function() {
     expect(botMaster.bots).to.have.length(2);
     // Change the source to force reload.
     Source.findOne({}, function(err, source) {
-      botMaster.once('botMaster:addedBot', function(){
+      botMaster.once('botMaster:addedBot', function() {
         expect(botMaster.bots).to.have.length(2);
         expect(botMaster._getBot(source._id).source.keywords).to.equal('foo');
         done();

--- a/test/lib.fetching.bot-master.test.js
+++ b/test/lib.fetching.bot-master.test.js
@@ -1,8 +1,5 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
-var request = require('supertest');
-var _ = require('underscore');
-var EventEmitter = require('events').EventEmitter;
 var botMaster = require('../lib/fetching/bot-master');
 var Bot = require('../lib/fetching/bot');
 var Source = require('../models/source');
@@ -80,4 +77,7 @@ describe('BotMaster', function() {
     expect(botMaster.bots).to.be.empty;
     done();
   });
+
+  after(utils.wipeModels([Source]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.bot.test.js
+++ b/test/lib.fetching.bot.test.js
@@ -6,7 +6,7 @@ var Report = require('../models/report');
 
 describe('Bot', function() {
   before(function(done) {
-    bot = botFactory.create({media: 'dummy', keywords: 't', interval: 500});
+    bot = botFactory.create({ media: 'dummy', keywords: 't', interval: 500 });
     done();
   });
 

--- a/test/lib.fetching.bot.test.js
+++ b/test/lib.fetching.bot.test.js
@@ -1,7 +1,8 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var botFactory = require('../lib/fetching/bot-factory');
 var ContentService = require('../lib/fetching/content-service');
+var Report = require('../models/report');
 
 describe('Bot', function() {
   before(function(done) {
@@ -51,4 +52,5 @@ describe('Bot', function() {
     bot.clearQueue();
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.bots.pull-bot.test.js
+++ b/test/lib.fetching.bots.pull-bot.test.js
@@ -7,9 +7,9 @@ var Source = require('../models/source');
 
 describe('Pull bot', function() {
   before(function(done) {
-    var source = new Source({nickname: 'dummy-pull', media: 'dummy-pull'});
+    var source = new Source({ nickname: 'dummy-pull', media: 'dummy-pull' });
     var contentService = contentServiceFactory.create(source);
-    pullBot = new PullBot({source: source, contentService: contentService, interval: 100});
+    pullBot = new PullBot({ source: source, contentService: contentService, interval: 100 });
     done();
   });
 

--- a/test/lib.fetching.bots.pull-bot.test.js
+++ b/test/lib.fetching.bots.pull-bot.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var PullBot = require('../lib/fetching/bots/pull-bot');
 var Bot = require('../lib/fetching/bot');
@@ -30,4 +30,5 @@ describe('Pull bot', function() {
     pullBot.start();
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.bots.push-bot.test.js
+++ b/test/lib.fetching.bots.push-bot.test.js
@@ -7,9 +7,9 @@ var Source = require('../models/source');
 
 describe('Push bot', function() {
   before(function(done) {
-    var source = new Source({nickname: 't', media: 'dummy', keywords: 't'});
+    var source = new Source({ nickname: 't', media: 'dummy', keywords: 't' });
     var contentService = contentServiceFactory.create(source);
-    pushBot = new PushBot({source: source, contentService: contentService});
+    pushBot = new PushBot({ source: source, contentService: contentService });
     done();
   });
 

--- a/test/lib.fetching.bots.push-bot.test.js
+++ b/test/lib.fetching.bots.push-bot.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var PushBot = require('../lib/fetching/bots/push-bot');
 var Bot = require('../lib/fetching/bot');
@@ -29,4 +29,5 @@ describe('Push bot', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.circular-queue.test.js
+++ b/test/lib.fetching.circular-queue.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var CircularQueue = require('../lib/fetching/circular-queue');
 
@@ -75,4 +75,5 @@ describe('Circular queue', function() {
     done();
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.content-service.test.js
+++ b/test/lib.fetching.content-service.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var contentServiceFactory = require('../lib/fetching/content-service-factory');
 var ContentService = require('../lib/fetching/content-service');
@@ -25,4 +25,6 @@ describe('Content service', function() {
       done();
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.content-service.test.js
+++ b/test/lib.fetching.content-service.test.js
@@ -7,7 +7,7 @@ var Source = require('../models/source');
 
 describe('Content service', function() {
   before(function(done) {
-    var source = new Source({nickname: 't', media: 'dummy', keywords: 't'});
+    var source = new Source({ nickname: 't', media: 'dummy', keywords: 't' });
     contentService = contentServiceFactory.create(source);
     done();
   });

--- a/test/lib.fetching.content-services.elmo-content-service.test.js
+++ b/test/lib.fetching.content-services.elmo-content-service.test.js
@@ -1,5 +1,4 @@
-require('./init');
-var util = require('util');
+var utils = require('./init');
 var expect = require('chai').expect;
 var fs = require('fs');
 var ELMOContentService = require('../lib/fetching/content-services/elmo-content-service');
@@ -29,7 +28,7 @@ describe('ELMO content service', function() {
 
   it('should fetch empty content', function(done) {
     var service = stubWithFixture('elmo-0.json');
-    expectToNotEmitReport(service, done);
+    utils.expectToNotEmitReport(service, done);
     expect(service._lastReportDate).to.be.undefined;
     service.once('error', function(err) {
       done(err);
@@ -74,7 +73,7 @@ describe('ELMO content service', function() {
 
     it('should emit a missing URL error', function(done) {
       var service = new ELMOContentService({});
-      expectToNotEmitReport(service, done);
+      utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Missing ELMO URL', done);
       service.fetch({maxCount: 50}, function(){});
     });
@@ -86,16 +85,18 @@ describe('ELMO content service', function() {
       service._httpRequest = function(params, callback) {
         process.nextTick(function() { callback({message: 'Unauthorized'}); });
       };
-      expectToNotEmitReport(service, done);
+      utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Unauthorized', done);
       service.fetch({maxCount: 50}, function(){});
     });
 
     it('should emit json parse error', function(done) {
       var service = stubWithFixture('elmo-bad.json');
-      expectToNotEmitReport(service, done);
+      utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Parse error: Unexpected end of input', done);
       service.fetch({maxCount: 50}, function(){});
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.content-services.elmo-content-service.test.js
+++ b/test/lib.fetching.content-services.elmo-content-service.test.js
@@ -9,11 +9,11 @@ var contentServiceFactory = require('../lib/fetching/content-service-factory');
 // If service is null, creates an ElmoContentService
 function stubWithFixture(fixtureFile, service) {
   // Create service if not provided.
-  service = service || new ELMOContentService({url: 'http://example.com'});
+  service = service || new ELMOContentService({ url: 'http://example.com' });
 
   // Make the stub function return the expected args (err, res, body).
   fixtureFile = 'test/fixtures/' + fixtureFile;
-  service._httpRequest = function(params, callback) { callback(null, {statusCode: 200}, fs.readFileSync(fixtureFile).toString()); };
+  service._httpRequest = function(params, callback) { callback(null, { statusCode: 200 }, fs.readFileSync(fixtureFile).toString()); };
 
   return service;
 }
@@ -21,7 +21,7 @@ function stubWithFixture(fixtureFile, service) {
 describe('ELMO content service', function() {
 
   it('factory should instantiate correct ELMO content service', function() {
-    var service = contentServiceFactory.create({media: 'elmo'});
+    var service = contentServiceFactory.create({ media: 'elmo' });
     expect(service).to.be.instanceOf(ContentService);
     expect(service).to.be.instanceOf(ELMOContentService);
   });
@@ -66,7 +66,7 @@ describe('ELMO content service', function() {
     setTimeout(function() { if (fetched == 2) done(); }, 100);
 
     // Run fetch
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   describe('errors', function() {
@@ -75,26 +75,26 @@ describe('ELMO content service', function() {
       var service = new ELMOContentService({});
       utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Missing ELMO URL', done);
-      service.fetch({maxCount: 50}, function(){});
+      service.fetch({ maxCount: 50 }, function() {});
     });
 
     it('should emit an unauthorized token error', function(done) {
-      var service = new ELMOContentService({url: 'https://example.com', authToken: '123'});
+      var service = new ELMOContentService({ url: 'https://example.com', authToken: '123' });
 
       // Stub the content service to return 403
       service._httpRequest = function(params, callback) {
-        process.nextTick(function() { callback({message: 'Unauthorized'}); });
+        process.nextTick(function() { callback({ message: 'Unauthorized' }); });
       };
       utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Unauthorized', done);
-      service.fetch({maxCount: 50}, function(){});
+      service.fetch({ maxCount: 50 }, function() {});
     });
 
     it('should emit json parse error', function(done) {
       var service = stubWithFixture('elmo-bad.json');
       utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Parse error: Unexpected end of input', done);
-      service.fetch({maxCount: 50}, function(){});
+      service.fetch({ maxCount: 50 }, function() {});
     });
   });
 

--- a/test/lib.fetching.content-services.facebook-content-service.test.js
+++ b/test/lib.fetching.content-services.facebook-content-service.test.js
@@ -1,6 +1,4 @@
-require('./init');
-var util = require('util');
-var fs = require('fs');
+var utils = require('./init');
 var expect = require('chai').expect;
 var FacebookContentService = require('../lib/fetching/content-services/facebook-content-service');
 var ContentService = require('../lib/fetching/content-service');
@@ -28,7 +26,7 @@ describe('Facebook content service', function() {
 
   it('should fetch empty content', function(done) {
     var service = stubWithFixture('facebook-0.json');
-    expectToNotEmitReport(service, done);
+    utils.expectToNotEmitReport(service, done);
     service.once('error', function(err) { done(err); });
     setTimeout(done, 100);
   });
@@ -120,9 +118,11 @@ describe('Facebook content service', function() {
 
     it('should emit a missing URL error', function(done) {
       var service = new FacebookContentService({url: ''});
-      expectToNotEmitReport(service, done);
+      utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Missing Facebook URL', done);
       service.fetch({maxCount: 50}, function(){});
     });
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.content-services.facebook-content-service.test.js
+++ b/test/lib.fetching.content-services.facebook-content-service.test.js
@@ -7,7 +7,7 @@ var ContentService = require('../lib/fetching/content-service');
 // If service is null, creates a dummy FacebookContentService
 function stubWithFixture(fixtureFile, service) {
   // Create service if not provided.
-  service = service || new FacebookContentService({url: 'http://example.com'});
+  service = service || new FacebookContentService({ url: 'http://example.com' });
 
   // Make the stub function return the expected args (err, data).
   fixtureFile = './fixtures/' + fixtureFile;
@@ -32,7 +32,7 @@ describe('Facebook content service', function() {
   });
 
   it('should grab the correct source given multiple url types', function() {
-    var service = new FacebookContentService({url: "http://test.com/"});
+    var service = new FacebookContentService({ url: "http://test.com/" });
     expect(service._getSourceFromUrl('http://facebook.com/cocacola')).to.equal('cocacola');
     expect(service._getSourceFromUrl('https://www.facebook.com/CocaColaUnitedStates/?brand_redir=40796308305&test=2'))
         .to.equal('CocaColaUnitedStates');
@@ -74,13 +74,13 @@ describe('Facebook content service', function() {
     // Give enough time for extra report to appear.
     setTimeout(function() { if (fetched == 3) done(); }, 100);
 
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   it('should get new comments from old posts, excluding already added posts', function(done) {
 
     var service = stubWithFixture('facebook-1.json');
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
 
     stubWithFixture('facebook-2.json', service);
     service.once('error', function(err) { done(err); });
@@ -111,16 +111,16 @@ describe('Facebook content service', function() {
     // Give enough time for extra report to appear.
     setTimeout(function() { if (fetched == 3) done(); }, 100);
 
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   describe('Errors', function() {
 
     it('should emit a missing URL error', function(done) {
-      var service = new FacebookContentService({url: ''});
+      var service = new FacebookContentService({ url: '' });
       utils.expectToNotEmitReport(service, done);
       expectToEmitError(service, 'Missing Facebook URL', done);
-      service.fetch({maxCount: 50}, function(){});
+      service.fetch({ maxCount: 50 }, function() {});
     });
   });
 

--- a/test/lib.fetching.content-services.rss-content-service.test.js
+++ b/test/lib.fetching.content-services.rss-content-service.test.js
@@ -8,11 +8,11 @@ var path = require('path');
 // If service is null, creates a dummy FacebookContentService
 function stubWithFixture(fixtureFile, service) {
   // Create service if not provided.
-  service = service || new RSSContentService({url: 'http://example.com'});
+  service = service || new RSSContentService({ url: 'http://example.com' });
 
   // Make the stub function return the expected args (err, data).
   fixtureFile = 'test/fixtures/' + fixtureFile;
-  service._doRequest = function(callback) { callback(null, {statusCode: 200}, fs.createReadStream(fixtureFile)); };
+  service._doRequest = function(callback) { callback(null, { statusCode: 200 }, fs.createReadStream(fixtureFile)); };
 
   return service;
 }
@@ -59,13 +59,13 @@ describe('RSS content service', function() {
     // Give enough time for extra report to appear.
     setTimeout(function() { if (fetched == 2) done(); }, 100);
 
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   it('should avoid duplicates', function(done) {
     // Fetch first time.
     var service = stubWithFixture('rss-good-1.xml');
-    service.fetch({maxCount: 50}, function(){
+    service.fetch({ maxCount: 50 }, function() {
 
       // Stub for second fetch, which has one overlapping item.
       stubWithFixture('rss-good-2.xml', service);
@@ -90,7 +90,7 @@ describe('RSS content service', function() {
       setTimeout(function() { if (fetched == 2) done(); }, 100);
 
       // Run second fetch.
-      service.fetch({maxCount: 50}, function(){});
+      service.fetch({ maxCount: 50 }, function() {});
     });
   });
 
@@ -112,7 +112,7 @@ describe('RSS content service', function() {
       done();
     });
 
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   it('should emit errors for malformed data', function(done) {
@@ -132,7 +132,7 @@ describe('RSS content service', function() {
       done();
     });
 
-    service.fetch({maxCount: 50}, function(){});
+    service.fetch({ maxCount: 50 }, function() {});
   });
 
   after(utils.expectModelsEmpty);

--- a/test/lib.fetching.content-services.rss-content-service.test.js
+++ b/test/lib.fetching.content-services.rss-content-service.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var RSSContentService = require('../lib/fetching/content-services/rss-content-service');
 var fs = require('fs');
@@ -21,7 +21,7 @@ describe('RSS content service', function() {
 
   it('should fetch empty content', function(done) {
     var service = stubWithFixture('rss-empty.json');
-    expectToNotEmitReport(service, done);
+    utils.expectToNotEmitReport(service, done);
     service.once('error', function(err) { done(err); });
     setTimeout(done, 100);
   });
@@ -134,4 +134,6 @@ describe('RSS content service', function() {
 
     service.fetch({maxCount: 50}, function(){});
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.content-services.twitter-content-service.test.js
+++ b/test/lib.fetching.content-services.twitter-content-service.test.js
@@ -6,12 +6,12 @@ var TwitterContentService = require('../lib/fetching/content-services/twitter-co
 describe('Twitter content service', function() {
 
   it('should handle incoming tweets properly', function(done) {
-    var service = new TwitterContentService({keywords: 't'});
+    var service = new TwitterContentService({ keywords: 't' });
 
     // Stub getStream method to return fake stream we control.
     var fakeStream = new EventEmitter();
-    fakeStream.stop = function(){};
-    service._getStream = function() { return fakeStream; }
+    fakeStream.stop = function() {};
+    service._getStream = function() { return fakeStream; };
 
     // Setup handler.
     service.once('report', function(reportData) {
@@ -31,7 +31,7 @@ describe('Twitter content service', function() {
     fakeStream.emit('tweet', {
       created_at: new Date(2012, 3, 4, 12, 0, 0),
       text: 'foo bar baz',
-      user: {screen_name: 'bozo'},
+      user: { screen_name: 'bozo' },
       id_str: '123'
     });
   });

--- a/test/lib.fetching.content-services.twitter-content-service.test.js
+++ b/test/lib.fetching.content-services.twitter-content-service.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var EventEmitter = require('events').EventEmitter;
 var TwitterContentService = require('../lib/fetching/content-services/twitter-content-service');
@@ -36,4 +36,5 @@ describe('Twitter content service', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.fetching.report-queue.test.js
+++ b/test/lib.fetching.report-queue.test.js
@@ -1,24 +1,25 @@
-require('./init');
+'use strict';
+
+var utils = require('./init');
 var expect = require('chai').expect;
 var reportQueue = require('../lib/fetching/report-queue');
-var reportWriter = require('../lib/fetching/report-writer');
 var botFactory = require('../lib/fetching/bot-factory');
 var botMaster = require('../lib/fetching/bot-master');
-var CircularQueue = require('../lib/fetching/circular-queue');
-var Report = require('../models/report');
 var Source = require('../models/source');
+var Report = require('../models/report');
 
 describe('Report queue', function() {
+  var one, two, three;
 
   describe('base functions', function() {
     before(function(done) {
       botMaster.kill();
       reportQueue.clear();
-      one = botFactory.create(new Source({nickname: '1', media: 'dummy', keywords: 'one'}));
+      one = botFactory.create(new Source({ nickname: '1', media: 'dummy', keywords: 'one' }));
       one.start();
-      two = botFactory.create(new Source({nickname: '2', media: 'dummy', keywords: 'two'}));
+      two = botFactory.create(new Source({ nickname: '2', media: 'dummy', keywords: 'two' }));
       two.start();
-      three = botFactory.create(new Source({nickname: '3', media: 'dummy', keywords: 'three'}));
+      three = botFactory.create(new Source({ nickname: '3', media: 'dummy', keywords: 'three' }));
       three.start();
       // Stream data for 100ms
       setTimeout(function() {
@@ -76,9 +77,9 @@ describe('Report queue', function() {
       botMaster.kill();
       botMaster.addListeners('source', Source.schema);
       reportQueue.clear();
-      Source.create({nickname: 'one', media: 'dummy', keywords: 'one'});
-      Source.create({nickname: 'two', media: 'dummy', keywords: 'two'});
-      Source.create({nickname: 'three', media: 'dummy', keywords: 'three'});
+      Source.create({ nickname: 'one', media: 'dummy', keywords: 'one' });
+      Source.create({ nickname: 'two', media: 'dummy', keywords: 'two' });
+      Source.create({ nickname: 'three', media: 'dummy', keywords: 'three' });
       process.nextTick(function() {
         botMaster.start();
         done();
@@ -110,4 +111,6 @@ describe('Report queue', function() {
     });
   });
 
+  after(utils.wipeModels([Report, Source]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/lib.process-manager.test.js
+++ b/test/lib.process-manager.test.js
@@ -98,7 +98,7 @@ describe('Process manager', function() {
         .end(function(err, res) {
           if (err) return done(err);
           process.nextTick(function() {
-            callback(res.body)
+            callback(res.body);
           });
         });
     };
@@ -110,7 +110,7 @@ describe('Process manager', function() {
         .end(function(err, res) {
           if (err) return done(err);
           setTimeout(function() {
-            callback()
+            callback();
           }, 500);
         });
     };
@@ -130,7 +130,7 @@ describe('Process manager', function() {
         expect(reports).to.contain.property('results');
         expect(reports.results).to.be.an.instanceof(Array);
         var length = reports.total;
-        createSource({nickname: 'lorem', media: 'dummy', keywords: 'Lorem ipsum'}, function() {
+        createSource({ nickname: 'lorem', media: 'dummy', keywords: 'Lorem ipsum' }, function() {
           toggleFetching('on', function() {
             setTimeout(function() {
               toggleFetching('off', function() {

--- a/test/lib.process-manager.test.js
+++ b/test/lib.process-manager.test.js
@@ -1,9 +1,8 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var processManager = require('../lib/process-manager');
-var Source = require('../models/source');
-var botMaster = require('../lib/fetching/bot-master');
 var request = require('supertest');
+var Source = require('../models/source');
 var Report = require('../models/report');
 
 /**
@@ -158,4 +157,6 @@ describe('Process manager', function() {
     });
   });
 
+  after(utils.wipeModels([Report, Source]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/manual/fetching.load.test.js
+++ b/test/manual/fetching.load.test.js
@@ -2,7 +2,7 @@ var request = require('request');
 var _ = require('underscore');
 var chance = new require('chance')();
 
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 // Notes:
 // * Aggie needs to be running for these tests to work.
 // * The test uses a dummy-bot that will output all dropped reports to STDOUT.
@@ -17,7 +17,7 @@ var chance = new require('chance')();
 // --interval=n                 [number of milliseconds between reports on each source]
 // --buffer=n                   [size of buffer for each source]
 // --baseurl=http://server:port [base url where server is running]
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 
 var args = {
   sources: 1, // number of sources
@@ -47,7 +47,7 @@ describe('Fetching load test', function() {
     };
     var remaining = args.sources;
     _.times(args.sources, function(i) {
-      request.post(args.baseurl + '/api/v1/source', {form: {nickname: chance.word(), media: 'dummy-fast', keywords: JSON.stringify(options)}}, function(err, res, body) {
+      request.post(args.baseurl + '/api/v1/source', { form: { nickname: chance.word(), media: 'dummy-fast', keywords: JSON.stringify(options) } }, function(err, res, body) {
         if (err) return done(err);
         if (--remaining === 0) done();
       });

--- a/test/manual/query-reports.load.test.js
+++ b/test/manual/query-reports.load.test.js
@@ -46,9 +46,9 @@ function fireRequest(cb) {
 // simulate a client by firing requests at frequent intervals
 function simulateClient(cb) {
   (function loop(n) {
-    setTimeout(function(){
+    setTimeout(function() {
       var start = moment();
-      fireRequest(function(err, res, body){
+      fireRequest(function(err, res, body) {
         if (err || res.statusCode !== 200) {
           errors++;
         }
@@ -66,7 +66,7 @@ function simulateClient(cb) {
 // log progress
 function logProgress() {
   (function repeat() {
-    setTimeout(function(){
+    setTimeout(function() {
       if (finished) return;
 
       var averageResponseTime = totalResponseTime / requestCount;
@@ -96,8 +96,8 @@ describe('Fetching load test', function() {
     logProgress();
 
     (function loop(n) {
-      setTimeout(function(){
-        simulateClient(function(){
+      setTimeout(function() {
+        simulateClient(function() {
           if (--n) return loop(n);
 
 

--- a/test/models.batch.test.js
+++ b/test/models.batch.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var Report = require('../models/report');
 var User = require('../models/user');
@@ -16,7 +16,7 @@ function timeAgo(miliseconds) {
 function loadUser(done) {
   User.findOne({}, function(err, u) {
     user = u;
-    done();
+    done(err);
   });
 }
 
@@ -34,10 +34,6 @@ function createReport(done) {
 }
 
 describe('Report', function() {
-  before(function (done) {
-    Report.remove({}, done);
-  });
-
   beforeEach(function(done) {
     async.series([loadUser, createReport], done);
   });
@@ -48,7 +44,7 @@ describe('Report', function() {
 
   it('should lock a batch', function(done) {
     async.series([
-      batch.lock.bind(batch, user._id), 
+      batch.lock.bind(batch, user._id),
       Report.find.bind(Report, {})
     ], function(err, result) {
       var reports = result[1];
@@ -80,7 +76,7 @@ describe('Report', function() {
 
   it('should load a batch', function(done) {
     async.series([
-      batch.lock.bind(Report, user._id), 
+      batch.lock.bind(Report, user._id),
       batch.load.bind(Report, user._id)
     ], function(err, result) {
       var reports = result[1];
@@ -92,12 +88,12 @@ describe('Report', function() {
   it('should checkout a new batch', function(done) {
     batch.checkout(user._id, function(err, reports) {
       expect(reports.length).to.eq(5);
-      
+
       reports.forEach(function(report) {
         expect(report.checkedOutAt).to.exist;
         expect(report.checkedOutBy).to.exist;
       });
-      
+
       done();
     });
   });
@@ -109,4 +105,5 @@ describe('Report', function() {
     });
   });
 
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.batch.test.js
+++ b/test/models.batch.test.js
@@ -24,12 +24,12 @@ function createReport(done) {
   var t = new Date();
 
   Report.create([
-    {storedAt: new Date(t.getTime() - 11000), content: 'one', flagged: true, checkedOutBy: user.id, checkedOutAt: timeAgo(6 * 1000 * 60)},
-    {storedAt: new Date(t.getTime() - 12000), content: 'two', flagged: false},
-    {storedAt: new Date(t.getTime() - 13000), content: 'three', flagged: false},
-    {storedAt: new Date(t.getTime() - 14000), content: 'four', flagged: false},
-    {storedAt: new Date(t.getTime() - 15000), content: 'five', flagged: false},
-    {storedAt: new Date(t.getTime() - 16000), content: 'six', flagged: true, read: true}
+    { storedAt: new Date(t.getTime() - 11000), content: 'one', flagged: true, checkedOutBy: user.id, checkedOutAt: timeAgo(6 * 1000 * 60) },
+    { storedAt: new Date(t.getTime() - 12000), content: 'two', flagged: false },
+    { storedAt: new Date(t.getTime() - 13000), content: 'three', flagged: false },
+    { storedAt: new Date(t.getTime() - 14000), content: 'four', flagged: false },
+    { storedAt: new Date(t.getTime() - 15000), content: 'five', flagged: false },
+    { storedAt: new Date(t.getTime() - 16000), content: 'six', flagged: true, read: true }
   ], done);
 }
 
@@ -98,7 +98,7 @@ describe('Report', function() {
     });
   });
 
-  it('should cancel batch', function (done) {
+  it('should cancel batch', function(done) {
     batch.cancel(user._id, function(err, num) {
       expect(num).to.eq(1);
       done();

--- a/test/models.delete.incident-with-reports.test.js
+++ b/test/models.delete.incident-with-reports.test.js
@@ -3,15 +3,6 @@ var expect = require('chai').expect;
 var Incident = require('../models/incident');
 var Report = require('../models/report');
 var async = require('async');
-var User = require('../models/user');
-
-var user;
-
-function removeAll(done) {
-  Report.remove({}, function() {
-    Incident.remove({}, done);
-  });
-}
 
 var id1;
 var id2;

--- a/test/models.delete.incident-with-reports.test.js
+++ b/test/models.delete.incident-with-reports.test.js
@@ -1,19 +1,11 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var Incident = require('../models/incident');
 var Report = require('../models/report');
-var _ = require('underscore');
 var async = require('async');
 var User = require('../models/user');
 
 var user;
-
-function loadUser(done) {
-  User.findOne({}, function(err, u) {
-    user = u;
-    done();
-  });
-}
 
 function removeAll(done) {
   Report.remove({}, function() {
@@ -53,11 +45,12 @@ function removeIncident(done) {
 
 describe('Deleting an incident that has associated reports', function() {
   before(function(done) {
-    async.series([loadUser, removeAll, createIncidents, createReports, removeIncident], done);
+    async.series([createIncidents, createReports, removeIncident], done);
   });
 
   it('should remove the incident', function(done) {
     Incident.find({ _id: id1 }, function(err, incidents) {
+      if (err) return done(err);
       expect(incidents.length).to.equal(0);
       done();
     });
@@ -65,6 +58,7 @@ describe('Deleting an incident that has associated reports', function() {
 
   it('should not remove the other incident', function(done) {
     Incident.find({ _id: id2 }, function(err, incidents) {
+      if (err) return done(err);
       expect(incidents.length).to.equal(1);
       done();
     });
@@ -72,6 +66,7 @@ describe('Deleting an incident that has associated reports', function() {
 
   it('should not affect other reports', function(done) {
     Report.find({ _incident: id2 }, function(err, reports) {
+      if (err) return done(err);
       expect(reports.length).to.equal(3);
       done();
     });
@@ -79,9 +74,12 @@ describe('Deleting an incident that has associated reports', function() {
 
   it('should remove reference to the incidents in the right reports', function(done) {
     Report.find({ _incident: id1 }, function(err, reports) {
+      if (err) return done(err);
       expect(reports.length).to.equal(0);
       done();
     });
   });
 
+  after(utils.wipeModels([Report, Incident]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.query.incident-query.test.js
+++ b/test/models.query.incident-query.test.js
@@ -1,8 +1,7 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var Incident = require('../models/incident');
 var IncidentQuery = require('../models/query/incident-query');
-var _ = require('underscore');
 
 var query;
 describe('Incident query attributes', function() {
@@ -90,4 +89,6 @@ describe('Incident query attributes', function() {
     });
   });
 
+  after(utils.wipeModels([Incident]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.query.incident-query.test.js
+++ b/test/models.query.incident-query.test.js
@@ -25,24 +25,24 @@ describe('Incident query attributes', function() {
 
   it('should normalize query', function() {
     var normalized = query.normalize();
-    expect(normalized).to.have.keys(['title', 'locationName', 'assignedTo','veracity']);
+    expect(normalized).to.have.keys(['title', 'locationName', 'assignedTo', 'veracity']);
     expect(normalized.title).to.equal('quick brown');
   });
 
   it('should hash a query into a string', function() {
-    var otherQuery = new IncidentQuery({title: 'Test'});
+    var otherQuery = new IncidentQuery({ title: 'Test' });
     var hash = IncidentQuery.hash(otherQuery);
     expect(hash).to.equal('{"title":"test","veracity":null}');
   });
 
   it('should compare queries', function() {
-    var otherQuery = new IncidentQuery({title: 'qUiCk BrOwN'});
+    var otherQuery = new IncidentQuery({ title: 'qUiCk BrOwN' });
     var similar = IncidentQuery.compare(otherQuery, query);
     expect(similar).to.be.true;
   });
 
   it('should query by title substring', function(done) {
-    (new IncidentQuery({title: 'The Quick Brown', status: "closed"})).run(function(err, incidents) {
+    (new IncidentQuery({ title: 'The Quick Brown', status: "closed" })).run(function(err, incidents) {
       if (err) return done(err);
 
       expect(incidents).to.have.keys(['total', 'results']);
@@ -55,7 +55,7 @@ describe('Incident query attributes', function() {
   });
 
   it('should query by veracity value', function(done) {
-    (new IncidentQuery({veracity: 'Confirmed true'})).run(function(err, incidents) {
+    (new IncidentQuery({ veracity: 'Confirmed true' })).run(function(err, incidents) {
       if (err) return done(err);
       expect(incidents).to.have.keys(['total', 'results']);
       expect(incidents.total).to.equal(1);
@@ -68,7 +68,7 @@ describe('Incident query attributes', function() {
   });
 
   it('should query by status value', function(done) {
-    (new IncidentQuery({status: 'open'})).run(function(err, incidents) {
+    (new IncidentQuery({ status: 'open' })).run(function(err, incidents) {
       if (err) return done(err);
 
       expect(incidents).to.have.keys(['total', 'results']);
@@ -82,7 +82,7 @@ describe('Incident query attributes', function() {
   });
 
   it('should query by multiple properties', function(done) {
-    (new IncidentQuery({title: 'quick', status: 'open'})).run(function(err, incidents) {
+    (new IncidentQuery({ title: 'quick', status: 'open' })).run(function(err, incidents) {
       if (err) return done(err);
       expect(incidents).to.have.keys(['total', 'results']);
       expect(incidents.total).to.equal(1);

--- a/test/models.query.incident-query.test.js
+++ b/test/models.query.incident-query.test.js
@@ -1,5 +1,8 @@
+'use strict';
+
 var utils = require('./init');
 var expect = require('chai').expect;
+var async = require('async');
 var Incident = require('../models/incident');
 var IncidentQuery = require('../models/query/incident-query');
 
@@ -11,11 +14,12 @@ describe('Incident query attributes', function() {
     });
     Incident.remove(function(err) {
       if (err) return done(err);
-      Incident.create({title: 'The quick brown fox', veracity: null, closed: true});
-      Incident.create({title: 'The slow white fox', veracity: true, closed: false});
-      Incident.create({title: 'The quick brown chicken', veracity: null, closed: false});
-      Incident.create({title: 'The brown quick fox', veracity: false, closed: true});
-      done();
+      async.each([
+        { title: 'The quick brown fox', veracity: null, closed: true },
+        { title: 'The slow white fox', veracity: true, closed: false },
+        { title: 'The quick brown chicken', veracity: null, closed: false },
+        { title: 'The brown quick fox', veracity: false, closed: true }
+      ], Incident.create.bind(Incident), done);
     });
   });
 

--- a/test/models.query.report-query.test.js
+++ b/test/models.query.report-query.test.js
@@ -4,7 +4,7 @@ var ReportQuery = require('../models/query/report-query');
 
 describe('Query attributes', function() {
   before(function() {
-    query = new ReportQuery({keywords: 'zero one two three'});
+    query = new ReportQuery({ keywords: 'zero one two three' });
   });
 
   it('should normalize query', function() {
@@ -13,13 +13,13 @@ describe('Query attributes', function() {
   });
 
   it('should hash a query into a string', function() {
-    var otherQuery = new ReportQuery({keywords: 'three two zero one'});
+    var otherQuery = new ReportQuery({ keywords: 'three two zero one' });
     var hash = ReportQuery.hash(otherQuery);
     expect(hash).to.equal('{"keywords":"three two zero one"}');
   });
 
   it('should compare queries', function() {
-    var otherQuery = new ReportQuery({keywords: 'zero one two three'});
+    var otherQuery = new ReportQuery({ keywords: 'zero one two three' });
     var similar = ReportQuery.compare(otherQuery, query);
     expect(similar).to.be.true;
   });

--- a/test/models.query.report-query.test.js
+++ b/test/models.query.report-query.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var ReportQuery = require('../models/query/report-query');
 
@@ -23,4 +23,6 @@ describe('Query attributes', function() {
     var similar = ReportQuery.compare(otherQuery, query);
     expect(similar).to.be.true;
   });
+
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.query.report.linked-incidents.test.js
+++ b/test/models.query.report.linked-incidents.test.js
@@ -1,25 +1,9 @@
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var Incident = require('../models/incident');
 var Report = require('../models/report');
-var _ = require('underscore');
 var async = require('async');
-var User = require('../models/user');
 var ReportQuery = require('../models/query/report-query');
-var user;
-
-function loadUser(done) {
-  User.findOne({}, function(err, u) {
-    user = u;
-    done();
-  });
-}
-
-function removeAll(done) {
-  Report.remove({}, function() {
-    Incident.remove({}, done);
-  });
-}
 
 var id1;
 var id2;
@@ -57,11 +41,12 @@ function createQueries(done) {
 
 describe('Querying for reports', function() {
   before(function(done) {
-    async.series([loadUser, removeAll, createIncidents, createReports, createQueries], done);
+    async.series([createIncidents, createReports, createQueries], done);
   });
 
   it('should retrieve 2 documents not linked to incidents', function(done) {
     queryNone.run(function(err, reports) {
+      if (err) return done(err);
       expect(reports.total).to.equal(2);
       done();
     });
@@ -69,8 +54,12 @@ describe('Querying for reports', function() {
 
   it('should retrieve 4 documents linked to any incident', function(done) {
     queryAny.run(function(err, reports) {
+      if (err) return done(err);
       expect(reports.total).to.equal(4);
       done();
     });
   });
+
+  after(utils.wipeModels([Report, Incident]));
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.query.report.linked-incidents.test.js
+++ b/test/models.query.report.linked-incidents.test.js
@@ -26,7 +26,7 @@ function createReports(done) {
     { _incident: id2 },
     { _incident: id2 },
     { _incident: '' },
-    {}, //incident: null
+    {}, // incident: null
   ], done);
 }
 
@@ -34,8 +34,8 @@ var queryNone;
 var queryAny;
 
 function createQueries(done) {
-  queryNone = new ReportQuery({incidentId:'none'});
-  queryAny = new ReportQuery({incidentId:'any'});
+  queryNone = new ReportQuery({ incidentId:'none' });
+  queryAny = new ReportQuery({ incidentId:'any' });
   done();
 }
 

--- a/test/models.source.test.js
+++ b/test/models.source.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var async = require('async');
 var Source = require('../models/source');
 
 describe('Source attributes', function() {
   it('should return validation errors', function(done) {
+    // This shouldn't get saved because it should error
     Source.create({ url: 'hey' }, function(err) {
       expect(err).to.have.keys(['message', 'name', 'errors']);
       expect(err.errors).to.have.keys(['nickname', 'url']);
@@ -17,6 +18,7 @@ describe('Source attributes', function() {
   });
 
   it('should return total number of errors', function(done) {
+    // These are not saved to the database
     var one = new Source({ nickname: 'one', type: 'dummy' });
     var two = new Source({ nickname: 'two', type: 'dummy' });
     async.parallel([
@@ -33,4 +35,7 @@ describe('Source attributes', function() {
       });
     });
   });
+
+  after(Source.remove.bind(Source, {}));
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.source.test.js
+++ b/test/models.source.test.js
@@ -1,10 +1,13 @@
+'use strict';
+
 require('./init');
 var expect = require('chai').expect;
+var async = require('async');
 var Source = require('../models/source');
 
 describe('Source attributes', function() {
   it('should return validation errors', function(done) {
-    Source.create({url: 'hey'}, function(err, source) {
+    Source.create({ url: 'hey' }, function(err) {
       expect(err).to.have.keys(['message', 'name', 'errors']);
       expect(err.errors).to.have.keys(['nickname', 'url']);
       expect(err.errors.nickname.type).to.equal('required');
@@ -14,17 +17,20 @@ describe('Source attributes', function() {
   });
 
   it('should return total number of errors', function(done) {
-    var one = new Source({nickname: 'one', type: 'dummy'});
-    var two = new Source({nickname: 'two', type: 'dummy'});
-    one.logEvent('error', 'Error 1');
-    two.logEvent('warning', 'Warning 1');
-    two.logEvent('warning', 'Warning 2');
-    setTimeout(function() {
+    var one = new Source({ nickname: 'one', type: 'dummy' });
+    var two = new Source({ nickname: 'two', type: 'dummy' });
+    async.parallel([
+      one.logEvent.bind(one, 'error', 'Error 1'),
+      two.logEvent.bind(two, 'warning', 'Warning 1'),
+      two.logEvent.bind(two, 'warning', 'Warning 2')
+    ],
+    function(err) {
+      if (err) return done(err);
       Source.countAllErrors(function(err, count) {
         if (err) return done(err);
         expect(count).to.equal(3);
         done();
       });
-    }, 100);
+    });
   });
 });

--- a/test/models.user.test.js
+++ b/test/models.user.test.js
@@ -1,4 +1,4 @@
-require('./init');
+var utils = require('./init');
 var chai = require('chai');
 var should = chai.should();
 var User = require('../models/user');
@@ -50,4 +50,7 @@ describe('User attributes', function() {
       done();
     });
   });
+
+  after(utils.removeUsersExceptAdmin);
+  after(utils.expectModelsEmpty);
 });

--- a/test/models.user.test.js
+++ b/test/models.user.test.js
@@ -34,7 +34,7 @@ describe('User attributes', function() {
   });
 
   it('should not allow users with duplicate username', function(done) {
-    var dupe = new User({username: 'test', email: 'janedoe2@gmail.com', password: 'password'});
+    var dupe = new User({ username: 'test', email: 'janedoe2@gmail.com', password: 'password' });
     dupe.save(function(err) {
       err.status.should.equal(422);
       err.message.should.equal('username_not_unique');
@@ -43,7 +43,7 @@ describe('User attributes', function() {
   });
 
   it('should not allow users with duplicate email', function(done) {
-    var dupe = new User({username: 'test2', email: 'janedoe@gmail.com', password: 'password'});
+    var dupe = new User({ username: 'test2', email: 'janedoe@gmail.com', password: 'password' });
     dupe.save(function(err) {
       err.status.should.equal(422);
       err.message.should.equal('email_not_unique');

--- a/test/public.angular.translations.test.js
+++ b/test/public.angular.translations.test.js
@@ -11,7 +11,7 @@
  *       want to add translations for a new language.
  */
 'use strict';
-require('./init');
+var utils = require('./init');
 var expect = require('chai').expect;
 var fs = require('graceful-fs');
 var path = require('path');
@@ -92,6 +92,8 @@ function testTranslationDir(dirname) {
         done();
       });
     });
+
+    after(utils.expectModelsEmpty);
   });
 }
 


### PR DESCRIPTION
A bunch of tests have subtle race conditions and bugs that only surface
when run with certain other tests. There are two main "sneaky" ways
that tests interact: (1) tests modify the database and fail to clean up
afterwards, and (2) tests share objects through `require` statements.

This change mainly adds a check at the end of each test file that
makes sure the database hasn't been modified. A handful of fixes are
then needed to get this check to pass.

Tests that had problems which are now fixed:
  `test/models.source.test.js`
  `test/lib.analytics.stats-master.test.js`
  `test/lib.api.v1.settings-controller.test.js`
  `test/lib.fetching.bot-master.test.js`
  `test/models.query.incident-query.test.js`