### PR TITLE
4932 missing strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "angular-cookies": "~1.2.29",
     "angular-translate": "^2.10.0",
+    "angular-translate-handler-log": "^2.11.1",
     "angular-translate-loader-static-files": "^2.10.0",
     "async": "^0.9.0",
     "bcrypt-nodejs": "0.0.3",

--- a/public/angular/js/app.js
+++ b/public/angular/js/app.js
@@ -10,10 +10,11 @@ require('../vendor/select2/ui-select2');
 require('./loading-bar');
 require('angular-translate');
 require('angular-translate-loader-static-files');
+require('angular-translate-handler-log');
 require('angular-cookies');
 
-angular.module('Aggie', ['ui.router', 'ui.bootstrap', 'ngResource', 
-  'pascalprecht.translate', 'ui.select2', 'ngSanitize', 'ngAutocomplete', 
+angular.module('Aggie', ['ui.router', 'ui.bootstrap', 'ngResource',
+  'pascalprecht.translate', 'ui.select2', 'ngSanitize', 'ngAutocomplete',
   'angular-loading-bar', 'ngCookies'])
 
 .config(['$urlRouterProvider', '$locationProvider',
@@ -34,7 +35,7 @@ angular.module('Aggie', ['ui.router', 'ui.bootstrap', 'ngResource',
 })
 
 .run([
-  '$rootScope', '$urlRouter', '$location', 'AuthService', '$state', 
+  '$rootScope', '$urlRouter', '$location', 'AuthService', '$state',
   'FlashService', '$cookies', '$translate',
   function ($rootScope, $urlRouter, $location, AuthService, $state, flash,
             $cookies, $translate) {

--- a/public/angular/js/translations.js
+++ b/public/angular/js/translations.js
@@ -9,6 +9,7 @@ angular.module('Aggie').config([
     })
     .preferredLanguage('en')
     .fallbackLanguage(['en', 'debug'])
-    .useSanitizeValueStrategy('sanitizeParameters');
+    .useSanitizeValueStrategy('sanitizeParameters')
+    .useMissingTranslationHandlerLog();
   }
 ]);

--- a/public/angular/templates/incidents/show.html
+++ b/public/angular/templates/incidents/show.html
@@ -7,7 +7,7 @@
 
 <div ng-show="currentUser.can('edit data')" class="button-row">
   <button ng-controller="IncidentFormModalController" class="btn btn-info margin-right" ng-click="edit(incident)" translate>Edit</button>
-  <button class="btn btn-info" aggie-confirm="{{ 'Are you sure you want to delete this incident?' | translate }}" on-confirm="delete()" translate>Delete</button>
+  <button class="btn btn-info" aggie-confirm="{{ 'Are you sure you want to delete this incident?' | translate }}" on-confirm="delete()">Delete</button>
 </div>
 
 <br/><br/>

--- a/public/angular/translations/locale-en.json
+++ b/public/angular/translations/locale-en.json
@@ -348,5 +348,16 @@
   "Total Reports": "Total Reports",
   "Reports/min": "Reports/min",
   "Escalated Incidents": "Escalated Incidents",
-  "Mark all Unread": "Mark all Unread"
+  "Mark all Unread": "Mark all Unread",
+  "Sorry, we had some trouble finding your user account. Please log in again.": "Sorry, we had some trouble finding your user account. Please log in again.",
+  "You must be logged in before accessing that page.": "You must be logged in before accessing that page.",
+  "ELMO": "ELMO",
+  "Facebook": "Facebook",
+  "Rss": "Rss",
+  "Twitter": "Twitter",
+  "Mark all Read": "Mark all Read",
+  "Confirmed true": "Confirmed true",
+  "Confirmed false": "Confirmed false",
+  "Unescalated": "Unescalated",
+  "Assign To": "Assign To"
 }


### PR DESCRIPTION
If angular translate (through the directive, filter, immediate, etc.) is
passed a translation ID that can't be found, it will now log an error
to the browser's debug console.

This adds a handful of those missing translations and fixes a
bug in one translation.