### PR TITLE
4943 and 4939 Add button appearing twice and report redirection.

### DIFF
--- a/public/angular/templates/incidents/report_incident_modal.html
+++ b/public/angular/templates/incidents/report_incident_modal.html
@@ -6,7 +6,7 @@
     </h4>
   </div>
   <div class="modal-body">
-    <p ng-hide="incidents" class="info">{{"Sorry, but we couldn't find any incidents. You can" | translate}} <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(report)">{{'create a new incident' | translate}}</button>.</p>
+    <p ng-hide="incidents" class="info">{{"Sorry, but we couldn't find any incidents. You can" | translate}} <button type="button" class="btn-text" ng-controller="IncidentFormModalController" ng-click="create(reports)">{{'create a new incident' | translate}}</button>.</p>
 
     <div ng-show="incidents">
 

--- a/public/angular/templates/reports/table.html
+++ b/public/angular/templates/reports/table.html
@@ -43,11 +43,6 @@
             <strong ng-if="!r._incident && currentUser.can('edit data')">Add</strong>
           </a>
         </div>
-        <div ng-if="incidents.length > 2">
-          <a ng-controller="IncidentFormModalController" ng-click="create(r)" class="table-primary">
-            <strong ng-if="!r._incident">Add</strong>
-          </a>
-        </div>
         <a class="remove" ng-show="r._incident" ng-click="unlinkIncident(r)">x</a>
       </td>
       <td class="flagged text-center">


### PR DESCRIPTION
PR #169 for 4599 removed the alternate "Add", and then PR #167 for 1785 added it back in improperly.

This fix leaves a bit to be desired, but it is very small and solves both of these bugs. Optimally, we would still use the `IncidentFormModalController` when there are no incidents yet. Adapting this modal for the reports page would take some extra work, however.