### PR TITLE
Fixes duplication of reports and other events

### DIFF
--- a/lib/fetching.js
+++ b/lib/fetching.js
@@ -21,6 +21,7 @@ botMaster.init(function() {
     subclass: 'schema',
     emitterModule: 'api'
   }));
+  // The below commented code is the change suggested in PR 172.
   /*
   botMaster.addListeners('source', childProcess.setupEventProxy({
     emitter: '/models/source',

--- a/lib/fetching.js
+++ b/lib/fetching.js
@@ -21,11 +21,13 @@ botMaster.init(function() {
     subclass: 'schema',
     emitterModule: 'api'
   }));
+  /*
   botMaster.addListeners('source', childProcess.setupEventProxy({
     emitter: '/models/source',
     subclass: 'schema',
     emitterModule: 'fetching'
   }));
+  */
   botMaster.addListeners('fetching', childProcess.setupEventProxy({
     emitter: '/lib/api/v1/settings-controller',
     emitterModule: 'api'

--- a/lib/fetching.js
+++ b/lib/fetching.js
@@ -21,14 +21,6 @@ botMaster.init(function() {
     subclass: 'schema',
     emitterModule: 'api'
   }));
-  // The below commented code is the change suggested in PR 172.
-  /*
-  botMaster.addListeners('source', childProcess.setupEventProxy({
-    emitter: '/models/source',
-    subclass: 'schema',
-    emitterModule: 'fetching'
-  }));
-  */
   botMaster.addListeners('fetching', childProcess.setupEventProxy({
     emitter: '/lib/api/v1/settings-controller',
     emitterModule: 'api'

--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -164,8 +164,8 @@ BotMaster.prototype._loadAll = function(callback) {
   // Find sources from the database
   Source.find({ media: { '$ne': null } }, function(err, sources) {
     if (err) return callback(err);
-    async.each(sources, function(s,c){
-       self._loadOne(s,c); 
+    async.each(sources, function(s, c) {
+       self._loadOne(s, c);
     }, callback);
   });
 };

--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -1,5 +1,6 @@
 // Creates and destroys bots as sources are created, enabled, disabled, destroyed, etc.
 // Watches for fetching to be turned on and off and disables/enables bots accordingly.
+'use strict';
 
 var _ = require('underscore');
 var Source = require('../../models/source');
@@ -9,16 +10,16 @@ var util = require('util');
 var config = require('../../config/secrets');
 var async = require('async');
 
-var BotMaster = function() {
+function BotMaster() {
   this.bots = [];
   this.enabled = config.get().fetching;
-};
+}
 
 util.inherits(BotMaster, EventEmitter);
 
 BotMaster.prototype.init = function(callback) {
-  this._loadAll(callback || function(){});
-}
+  this._loadAll(callback || _.noop);
+};
 
 // Initialize event listeners
 BotMaster.prototype.addListeners = function(type, emitter) {
@@ -97,7 +98,7 @@ BotMaster.prototype._addSourceListeners = function(emitter) {
   // Load bot when source is saved
   emitter.on('source:save', function(source) {
     // We pass the ID here as that's all we might have.
-    self._loadOne(source._id, function(){});
+    self._loadOne(source._id, function() {});
   });
 
   // Kill bots when removed from datbase
@@ -124,6 +125,12 @@ BotMaster.prototype._addSourceListeners = function(emitter) {
     }
     var bot = self._getBot(source._id);
     if (bot) bot.stop();
+  });
+
+  // Listen to `disable` event from the fetching process
+  // This is Andres' initial suggestion for a fix to Issue 4602
+  Source.schema.on('source:disable', function(source) {
+    self._getBot(source._id).stop();
   });
 };
 
@@ -155,9 +162,11 @@ BotMaster.prototype._addSettingsListeners = function(emitter) {
 BotMaster.prototype._loadAll = function(callback) {
   var self = this;
   // Find sources from the database
-  Source.find({media: {'$ne': null }}, function(err, sources) {
+  Source.find({ media: { '$ne': null } }, function(err, sources) {
     if (err) return callback(err);
-    async.each(sources, function(s,c){ self._loadOne(s,c); }, callback);
+    async.each(sources, function(s,c){
+       self._loadOne(s,c); 
+    }, callback);
   });
 };
 
@@ -167,8 +176,8 @@ BotMaster.prototype._loadOne = function(sourceObjOrId, callback) {
   var self = this;
 
   // Resolve argument.
-  var sourceId = (sourceObjOrId instanceof Object) ? sourceObjOrId._id : sourceObjOrId;
-  var source = (sourceObjOrId instanceof Object) ? sourceObjOrId : null;
+  var sourceId = sourceObjOrId instanceof Object ? sourceObjOrId._id : sourceObjOrId;
+  var source = sourceObjOrId instanceof Object ? sourceObjOrId : null;
 
   // If bot for this source already exists, kill so that it can be re-added
   var bot = this._getBot(sourceId);

--- a/lib/fetching/bot-master.js
+++ b/lib/fetching/bot-master.js
@@ -86,6 +86,7 @@ BotMaster.prototype.enableBot = function(bot) {
 
 // Stop bot from current process
 BotMaster.prototype.disableBot = function(bot) {
+  // if (!this.enabled) return;
   bot.stop();
 };
 
@@ -107,12 +108,20 @@ BotMaster.prototype._addSourceListeners = function(emitter) {
 
   // Listen to `enable` event from the API process
   emitter.on('source:enable', function(source) {
+    // This should ensure fetching button does its job
+    if (!self.enabled) {
+      return;
+    }
     var bot = self._getBot(source._id);
     if (self.enabled && bot) bot.start();
   });
 
   // Listen to `disable` event from the API process
   emitter.on('source:disable', function(source) {
+    // This should ensure fetching button does its job
+    if (!self.enabled) {
+      return;
+    }
     var bot = self._getBot(source._id);
     if (bot) bot.stop();
   });

--- a/models/source.js
+++ b/models/source.js
@@ -44,7 +44,6 @@ sourceSchema.pre('save', function(next) {
   if (!this.isNew && this.isModified('unreadErrorCount')) {
     this._sourceErrorCountUpdated = true;
   }
-  
   if (!this.isNew && this.isModified('enabled')) {
     this._sourceStatusChanged = true;
   }

--- a/models/source.js
+++ b/models/source.js
@@ -44,9 +44,14 @@ sourceSchema.pre('save', function(next) {
   if (!this.isNew && this.isModified('unreadErrorCount')) {
     this._sourceErrorCountUpdated = true;
   }
-
+  // This is the code that says that if source is enabled, set true
+  // This does not handle if source is disabled
   if (!this.isNew && this.isModified('enabled')) {
     this._sourceStatusChanged = true;
+  }
+  // May be unnecessary if I check for fetching elsewhere
+  if(!this.isNew && this.isModified('disabled')) {
+    this._sourceStatusChanged = false;
   }
 
   // Only allow a single Twitter source
@@ -62,6 +67,7 @@ sourceSchema.pre('save', function(next) {
 
 sourceSchema.post('save', function() {
   if (this._sourceStatusChanged) {
+    // Maybe return here if fetching is disabled
     var event = (this.enabled) ? 'source:enable' : 'source:disable';
     sourceSchema.emit(event, {_id: this._id.toString()});
   }

--- a/models/source.js
+++ b/models/source.js
@@ -44,14 +44,9 @@ sourceSchema.pre('save', function(next) {
   if (!this.isNew && this.isModified('unreadErrorCount')) {
     this._sourceErrorCountUpdated = true;
   }
-  // This is the code that says that if source is enabled, set true
-  // This does not handle if source is disabled
+  
   if (!this.isNew && this.isModified('enabled')) {
     this._sourceStatusChanged = true;
-  }
-  // May be unnecessary if I check for fetching elsewhere
-  if(!this.isNew && this.isModified('disabled')) {
-    this._sourceStatusChanged = false;
   }
 
   // Only allow a single Twitter source
@@ -67,7 +62,6 @@ sourceSchema.pre('save', function(next) {
 
 sourceSchema.post('save', function() {
   if (this._sourceStatusChanged) {
-    // Maybe return here if fetching is disabled
     var event = (this.enabled) ? 'source:enable' : 'source:disable';
     sourceSchema.emit(event, {_id: this._id.toString()});
   }

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -6,7 +6,7 @@ var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 var expect = chai.expect;
-// var promise = protractor.promise;
+var promise = protractor.promise;
 
 
 describe('test duplication of reports with different settings', function() {
@@ -33,9 +33,8 @@ describe('test duplication of reports with different settings', function() {
   it('should listen with fetching:on and source:enabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
     utils.toggleFetching('On');
-    utils.toggleSource('SMS GH', 'On');
-    // Sleep before this is sent.
-    request('http://localhost:1111')
+    utils.toggleSource('SMS GH', 'On').then(function() {
+      request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
       .expect(200)
@@ -44,7 +43,8 @@ describe('test duplication of reports with different settings', function() {
           return done(err);
         }
       });
-    browser.get(browser.baseUrl + 'reports');
+    });
+    var reports = utils.getReports();
     // Check if there is only one. If not, throw error.
     utils.toggleSource('SMS GH', 'Off');
     utils.toggleFetching('Off');
@@ -54,9 +54,8 @@ describe('test duplication of reports with different settings', function() {
   it('should not listen with fetching:on and source:disabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
     utils.toggleFetching('On');
-    utils.toggleSource('SMS GH', 'Off');
-    // Sleep before this is sent.
-    request('http://localhost:1111')
+    utils.toggleSource('SMS GH', 'Off').then(function() {
+      request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
       .expect(200)
@@ -65,7 +64,8 @@ describe('test duplication of reports with different settings', function() {
           return done(err);
         }
       });
-    browser.get(browser.baseUrl + 'reports');
+    });
+    var reports = utils.getReports();
     // Check if there is any report. If there is, throw error.
     utils.toggleFetching('Off');
     done();
@@ -74,9 +74,8 @@ describe('test duplication of reports with different settings', function() {
   it('should not listening wtih fetching:off and source:enabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
     utils.toggleFetching('Off');
-    utils.toggleSource('SMS GH', 'On');
-    // Sleep before this is sent.
-    request('http://localhost:1111')
+    utils.toggleSource('SMS GH', 'On').then(function() {
+      request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
       .expect(200)
@@ -85,7 +84,8 @@ describe('test duplication of reports with different settings', function() {
           return done(err);
         }
       });
-    browser.get(browser.baseUrl + 'reports');
+    });
+    var reports = utils.getReports();
     // Check if there is any report. If there is, throw error.
     utils.toggleSource('SMS GH', 'Off');
     done();
@@ -94,9 +94,8 @@ describe('test duplication of reports with different settings', function() {
   it('should not listen with fetching:off and source:disabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
     utils.toggleFetching('Off');
-    utils.toggleSource('SMS GH', 'Off');
-    // Sleep before this is sent.
-    request('http://localhost:1111')
+    utils.toggleSource('SMS GH', 'Off').then(function() {
+      request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
       .expect(200)
@@ -105,7 +104,8 @@ describe('test duplication of reports with different settings', function() {
           return done(err);
         }
       });
-    browser.get(browser.baseUrl + 'reports');
+    });
+    var reports = utils.getReports();
     // Check if there is any report. If there is, throw error.
     done();
   });

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -28,13 +28,6 @@ describe('test duplication of reports with different settings', function() {
     defer.fulfill(true);
     return defer.promise;
   };
-/*
-  it('should add SMS Ghana source with keyword: test', function(done) {
-    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
-    utils.toggleSource('SMS GH', 'Off');
-    done();
-  });
-*/
   it('should listen with fetching:on and source:enabled', function(done) {
     chain()
     .then(function() {

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -6,7 +6,7 @@ var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 var expect = chai.expect;
-var promise = protractor.promise;
+// var promise = protractor.promise;
 
 
 describe('test duplication of reports with different settings', function() {
@@ -23,14 +23,18 @@ describe('test duplication of reports with different settings', function() {
   keyword: 'test'
   };
 
+/*
   it('should add SMS Ghana source with keyword: test', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    utils.toggleSource('SMS GH', 'Off');
     done();
   });
+*/
   it('should listen with fetching:on and source:enabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
     utils.toggleFetching('On');
     utils.toggleSource('SMS GH', 'On');
+    // Sleep before this is sent.
     request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
@@ -41,17 +45,68 @@ describe('test duplication of reports with different settings', function() {
         }
       });
     browser.get(browser.baseUrl + 'reports');
+    // Check if there is only one. If not, throw error.
+    utils.toggleSource('SMS GH', 'Off');
+    utils.toggleFetching('Off');
     done();
   });
-/*
-  it('should not listen with fetching:on and source:disabled', function() {
+
+  it('should not listen with fetching:on and source:disabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    utils.toggleFetching('On');
+    utils.toggleSource('SMS GH', 'Off');
+    // Sleep before this is sent.
+    request('http://localhost:1111')
+      .get('/smsghana')
+      .query(reqParams)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+      });
+    browser.get(browser.baseUrl + 'reports');
+    // Check if there is any report. If there is, throw error.
+    utils.toggleFetching('Off');
+    done();
   });
-  it('should not listen with fetching:off and source:disabled', function() {
+
+  it('should not listening wtih fetching:off and source:enabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    utils.toggleFetching('Off');
+    utils.toggleSource('SMS GH', 'On');
+    // Sleep before this is sent.
+    request('http://localhost:1111')
+      .get('/smsghana')
+      .query(reqParams)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+      });
+    browser.get(browser.baseUrl + 'reports');
+    // Check if there is any report. If there is, throw error.
+    utils.toggleSource('SMS GH', 'Off');
+    done();
   });
-  it('should not listening wtih fetching:off and source:enabled', function() {
+
+  it('should not listen with fetching:off and source:disabled', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    utils.toggleFetching('Off');
+    utils.toggleSource('SMS GH', 'Off');
+    // Sleep before this is sent.
+    request('http://localhost:1111')
+      .get('/smsghana')
+      .query(reqParams)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+      });
+    browser.get(browser.baseUrl + 'reports');
+    // Check if there is any report. If there is, throw error.
+    done();
   });
-*/
 });

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -18,11 +18,16 @@ describe('test duplication of reports with different settings', function() {
   afterEach(utils.resetBrowser);
   var reqParams = {
   from: '9845098450',
-  fulltext: 'lorem ipsum dolor',
+  fulltext: 'loremipsumdolor',
   date: '2016-09-01',
   keyword: 'test'
   };
 
+  var chain = function() {
+    var defer = promise.defer();
+    defer.fulfill(true);
+    return defer.promise;
+  };
 /*
   it('should add SMS Ghana source with keyword: test', function(done) {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
@@ -31,9 +36,17 @@ describe('test duplication of reports with different settings', function() {
   });
 */
   it('should listen with fetching:on and source:enabled', function(done) {
-    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
-    utils.toggleFetching('On');
-    utils.toggleSource('SMS GH', 'On').then(function() {
+    chain()
+    .then(function() {
+      utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    })
+    .then(function() {
+      utils.toggleFetching('On');
+    })
+    .then(function() {
+      utils.toggleSource('SMS GH', 'On');
+    })
+    .then(function() {
       request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
@@ -44,17 +57,25 @@ describe('test duplication of reports with different settings', function() {
         }
       });
     });
-    var reports = utils.getReports();
-    // Check if there is only one. If not, throw error.
+    browser.get(browser.baseUrl + 'reports');
+    expect(utils.getReports().count()).to.eventually.equal(1);
     utils.toggleSource('SMS GH', 'Off');
     utils.toggleFetching('Off');
+    utils.deleteSource('SMS GH', 'hello');
     done();
   });
-
   it('should not listen with fetching:on and source:disabled', function(done) {
-    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
-    utils.toggleFetching('On');
-    utils.toggleSource('SMS GH', 'Off').then(function() {
+    chain()
+    .then(function() {
+      utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    })
+    .then(function() {
+      utils.toggleFetching('On');
+    })
+    .then(function() {
+      utils.toggleSource('SMS GH', 'Off');
+    })
+    .then(function() {
       request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
@@ -65,36 +86,47 @@ describe('test duplication of reports with different settings', function() {
         }
       });
     });
-    var reports = utils.getReports();
-    // Check if there is any report. If there is, throw error.
+    expect(utils.getReports().count()).to.eventually.equal(0);
     utils.toggleFetching('Off');
+    utils.deleteSource('SMS GH', 'hello');
     done();
   });
 
   it('should not listening wtih fetching:off and source:enabled', function(done) {
-    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
-    utils.toggleFetching('Off');
-    utils.toggleSource('SMS GH', 'On').then(function() {
+    chain()
+    .then(function() {
+      utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    })
+    .then(function() {
+      utils.toggleFetching('Off');
+    })
+    .then(function() {
+      utils.toggleSource('SMS GH', 'On');
+    })
+    .then(function() {
       request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
-      .expect(200)
-      .end(function(err, res) {
-        if (err) {
-          return done(err);
-        }
-      });
+      .expect(200);
     });
-    var reports = utils.getReports();
-    // Check if there is any report. If there is, throw error.
+    expect(utils.getReports().count()).to.eventually.equal(0);
     utils.toggleSource('SMS GH', 'Off');
+    utils.deleteSource('SMS GH', 'hello');
     done();
   });
 
   it('should not listen with fetching:off and source:disabled', function(done) {
-    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
-    utils.toggleFetching('Off');
-    utils.toggleSource('SMS GH', 'Off').then(function() {
+    chain()
+    .then(function() {
+      utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    })
+    .then(function() {
+      utils.toggleFetching('Off');
+    })
+    .then(function() {
+      utils.toggleSource('SMS GH', 'Off');
+    })
+    .then(function() {
       request('http://localhost:1111')
       .get('/smsghana')
       .query(reqParams)
@@ -105,8 +137,8 @@ describe('test duplication of reports with different settings', function() {
         }
       });
     });
-    var reports = utils.getReports();
-    // Check if there is any report. If there is, throw error.
+    expect(utils.getReports().count()).to.eventually.equal(0);
+    utils.deleteSource('SMS GH', 'hello');
     done();
   });
 });

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var utils = require('./e2e-tools');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+var promise = protractor.promise;
+
+
+describe('test duplication of reports with different settings', function() {
+  before(utils.initDb);
+  after(utils.disconnectDropDb);
+
+  beforeEach(utils.resetDb);
+  beforeEach(utils.initAdmin.bind({}, 'asdfasdf'));
+  afterEach(utils.resetBrowser);
+
+  it('should add SMS Ghana source with keyword: test', function() {
+    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+  });
+  it('should listen with fetching:on and source:enabled', function() {
+
+  });
+  it('should not listen with fetching:on and source:disabled', function() {
+
+  });
+  it('should not listen with fetching:off and source:disabled', function() {
+
+  });
+  it('should not listening wtih fetching:off and source:enabled', function() {
+
+  });
+});

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -141,4 +141,33 @@ describe('test duplication of reports with different settings', function() {
     utils.deleteSource('SMS GH', 'hello');
     done();
   });
+  it('should not listen with fetching toggled from on to off and source:disabled', function(done) {
+    chain()
+    .then(function() {
+      utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    })
+    .then(function() {
+      utils.toggleFetching('On');
+    })
+    .then(function() {
+      utils.toggleFetching('Off');
+    })
+    .then(function() {
+      utils.toggleSource('SMS GH', 'Off');
+    })
+    .then(function() {
+      request('http://localhost:1111')
+      .get('/smsghana')
+      .query(reqParams)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+      });
+    });
+    expect(utils.getReports().count()).to.eventually.equal(0);
+    utils.deleteSource('SMS GH', 'hello');
+    done();
+  });
 });

--- a/test/end-to-end/duplication.test.js
+++ b/test/end-to-end/duplication.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('./e2e-tools');
+var request = require('supertest');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
@@ -15,20 +16,42 @@ describe('test duplication of reports with different settings', function() {
   beforeEach(utils.resetDb);
   beforeEach(utils.initAdmin.bind({}, 'asdfasdf'));
   afterEach(utils.resetBrowser);
+  var reqParams = {
+  from: '9845098450',
+  fulltext: 'lorem ipsum dolor',
+  date: '2016-09-01',
+  keyword: 'test'
+  };
 
-  it('should add SMS Ghana source with keyword: test', function() {
+  it('should add SMS Ghana source with keyword: test', function(done) {
+    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    done();
+  });
+  it('should listen with fetching:on and source:enabled', function(done) {
+    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
+    utils.toggleFetching('On');
+    utils.toggleSource('SMS GH', 'On');
+    request('http://localhost:1111')
+      .get('/smsghana')
+      .query(reqParams)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+      });
+    browser.get(browser.baseUrl + 'reports');
+    done();
+  });
+/*
+  it('should not listen with fetching:on and source:disabled', function() {
     utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
   });
-  it('should listen with fetching:on and source:enabled', function() {
-
-  });
-  it('should not listen with fetching:on and source:disabled', function() {
-
-  });
   it('should not listen with fetching:off and source:disabled', function() {
-
+    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
   });
   it('should not listening wtih fetching:off and source:enabled', function() {
-
+    utils.addSource('SMS GH', { nickname: 'hello', keywords: 'test' });
   });
+*/
 });

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -5,7 +5,6 @@ var _ = require('lodash');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 var Report = require('../../models/report');
-var request = require('supertest');
 
 chai.use(chaiAsPromised);
 var expect = chai.expect;

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -5,6 +5,7 @@ var _ = require('lodash');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 var Report = require('../../models/report');
+var request = require('supertest');
 
 chai.use(chaiAsPromised);
 var expect = chai.expect;
@@ -144,4 +145,12 @@ module.exports.getReports = function(pluckColumn) {
   return element.all(x.column(pluckColumn)).map(function(elem) {
     return elem.getText();
   });
+};
+
+module.exports.deleteSource = function(sourceName, nickname) {
+  browser.get(browser.baseUrl + 'sources');
+  element(by.linkText(nickname)).click();
+  element(by.buttonText('Delete')).click();
+  element(by.buttonText('Confirm')).click();
+  return;
 };

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -134,3 +134,14 @@ module.exports.toggleSource = function(sourceName, state) {
     .element(by.xpath('.//*[.="' + state + '"]')).click();
   return;
 };
+
+module.exports.getReports = function(pluckColumn) {
+  browser.get(browser.baseUrl + 'reports');
+  var x = by.repeater("r in visibleReports.toArray() | orderBy:'-storedAt'");
+  if (!pluckColumn) {
+    return element.all(x);
+  }
+  return element.all(x.column(pluckColumn)).map(function(elem) {
+    return elem.getText();
+  });
+};

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -97,7 +97,7 @@ module.exports.addSource = function(sourceName, params) {
   };
   browser.get(browser.baseUrl + 'sources');
   element(by.buttonText('Create Source')).click();
-  element(by.model('source.media')).$('[value="' + sourceList.sourceName + '"]').click();
+  element(by.model('source.media')).$('[value="' + sourceList[sourceName] + '"]').click();
   if (sourceName !== 'Twitter') {
     element(by.model('source.nickname')).sendKeys(params.nickname ? params.nickname : 'blank');
   }
@@ -106,5 +106,31 @@ module.exports.addSource = function(sourceName, params) {
   } else {
     element(by.model('source.url')).sendKeys(params.url);
   }
-  element(by.css('[type="submit"]')).click();
+  element(by.buttonText('Submit')).click();
+  return;
+};
+
+module.exports.toggleFetching = function(state) {
+  var stateMapping = {
+    On: true,
+    Off: false
+  };
+  browser.get(browser.baseUrl + 'settings');
+  element(by.css('[ng-click="toggle(' + stateMapping[state] + ')"]')).click();
+  return;
+};
+
+module.exports.toggleSource = function(sourceName, state) {
+  var sourceIconMapping = {
+    Twitter: 'twitter-source',
+    Facebook: 'facebook-source',
+    RSS: 'rss-source',
+    Elmo: 'elmo-source',
+    'SMS GH': 'smsgh-source'
+  };
+  browser.get(browser.baseUrl + 'sources');
+  element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
+    .element(by.xpath('..'))
+    .element(by.xpath('.//*[.="' + state + '"]')).click();
+  return;
 };

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -4,11 +4,17 @@ var dbTools = require('../database-tools');
 var _ = require('lodash');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
+var Report = require('../../models/report');
 
 chai.use(chaiAsPromised);
 var expect = chai.expect;
+var promise = protractor.promise;
 
 module.exports = _.clone(dbTools);
+
+module.exports.resetBrowser = function() {
+  browser.manage().deleteAllCookies();
+};
 
 module.exports.init = function() {
   browser.get(browser.baseUrl);
@@ -16,29 +22,89 @@ module.exports.init = function() {
 
 module.exports.initAdmin = function(password) {
   module.exports.init();
-  expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'login');
+  var e1 = expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'login');
 
   element(by.model('user.username')).sendKeys('admin');
   element(by.model('user.password')).sendKeys('letmein1');
   element(by.css('[type="submit"]')).click();
-  expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reset_admin_password');
+  var e2 = expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reset_admin_password');
 
   element(by.model('user.password')).sendKeys(password);
   element(by.model('user.passwordConfirmation')).sendKeys(password);
   element(by.css('[type="submit"]')).click();
-  expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reports');
+  var e3 = expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reports');
+
+  return promise.all([e1, e2, e3]);
 };
 
 module.exports.logOut = function() {
   // Note: it would be nice if there were a more reliable way to get the logout
   // button.
   element(by.cssContainingText('li a', 'Log out')).click();
-  expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'login');
+  return expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'login');
 };
 
 module.exports.logIn = function(username, password) {
   element(by.model('user.username')).sendKeys(username);
   element(by.model('user.password')).sendKeys(password);
   element(by.css('[type="submit"]')).click();
-  expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reports');
+  return expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reports');
+};
+
+module.exports.makeReports = function(n, author, time, content) {
+  return function(done) {
+    Report.create(_.map(_.range(n), function(i) {
+      return {
+        author: author,
+        authoredAt: time ? new Date(time) : new Date(),
+        content: content ? i + ' ' + content : i
+      };
+    }), done);
+  };
+};
+
+module.exports.setFilter = function(filter) {
+  var e = expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'reports');
+  if (filter.keywords) {
+    element(by.model('searchParams.keywords')).sendKeys(filter.keywords);
+  }
+  if (filter.author) {
+    element(by.model('searchParams.author')).sendKeys(filter.author);
+  }
+  if (filter.time) {
+    // This will only work once: if you want to then change the filter the
+    // button will have different text and you'll have to select it some other
+    // way.
+    element(by.buttonText('Date/Time')).click();
+    // Also, it's important to do the 'before' time which is on the right of
+    // the modal, before the 'after' time, so that when we click Submit there
+    // isn't a dropdown covering the button.
+    element(by.model('times.before')).sendKeys(filter.time.before);
+    element(by.model('times.after')).sendKeys(filter.time.after);
+    element(by.buttonText('Submit')).click();
+  }
+  element(by.buttonText('Go')).click();
+  return e;
+};
+
+module.exports.addSource = function(sourceName, params) {
+  var sourceList = {
+    Twitter: 0,
+    Facebook: 1,
+    RSS: 2,
+    Elmo: 3,
+    'SMS GH': 4
+  };
+  browser.get(browser.baseUrl + 'sources');
+  element(by.buttonText('Create Source')).click();
+  element(by.model('source.media')).$('[value="' + sourceList.sourceName + '"]').click();
+  if (sourceName !== 'Twitter') {
+    element(by.model('source.nickname')).sendKeys(params.nickname ? params.nickname : 'blank');
+  }
+  if (sourceName === 'SMS GH' || sourceName === 'Twitter') {
+    element(by.model('source.keywords')).sendKeys(params.keywords);
+  } else {
+    element(by.model('source.url')).sendKeys(params.url);
+  }
+  element(by.css('[type="submit"]')).click();
 };

--- a/test/end-to-end/login.test.js
+++ b/test/end-to-end/login.test.js
@@ -2,12 +2,15 @@
 
 var utils = require('./e2e-tools');
 
-before(utils.initDb);
-after(utils.disconnectDropDb);
-
 describe('login page', function() {
+  before(utils.initDb);
+  after(utils.disconnectDropDb);
+
   beforeEach(utils.resetDb);
+  afterEach(utils.resetBrowser);
+
   it('should set the admin password', function() {
+    this.slow(12000);
     utils.initAdmin('asdfasdf');
     utils.logOut();
     utils.logIn('admin', 'asdfasdf');

--- a/test/end-to-end/protractor.conf.js
+++ b/test/end-to-end/protractor.conf.js
@@ -13,6 +13,7 @@ exports.config = {
 
   framework: 'mocha',
   mochaOpts: {
-    timeout: 20000
+    timeout: 20000,
+    slow: 2000
   }
 };


### PR DESCRIPTION
Events like report generation, bot creation etc were being duplicated because of two listeners set up to listen to the same events. There is still possibility of discovering a bug related to this in the future: there is a listener for all events emitted by the API process, but only for 1 event emitted by the Fetching process. But currently, this code fixes the known bugs related to this code. The changes to bot-master.js have been made to mimic Andres' PR (PR 171).
End to end tests: 
Some changes have been copied from Philip's other branch to avoid future merge conflicts.
Toolkit has some new useful functions which can be reused in other tests.
duplication-test.js: This is a reusable test which will add new source, listen for reports, and check if the correct number of reports are generated. This was designed to check duplication of reports.