### PR TITLE
5121 smsgh-content-service unsubscribe functionality

### DIFF
--- a/lib/fetching/bots/subscribe-bot.js
+++ b/lib/fetching/bots/subscribe-bot.js
@@ -21,8 +21,8 @@ SubscribeBot.prototype.start = function() {
 };
 
 SubscribeBot.prototype.stop = function() {
-  SubscribeBot.super_.prototype.stop.apply(this);
   this.contentService.unsubscribe(this.source.keywords);
+  SubscribeBot.super_.prototype.stop.apply(this);
 };
 
 module.exports = SubscribeBot;

--- a/lib/fetching/bots/subscribe-bot.js
+++ b/lib/fetching/bots/subscribe-bot.js
@@ -22,7 +22,7 @@ SubscribeBot.prototype.start = function() {
 
 SubscribeBot.prototype.stop = function() {
   SubscribeBot.super_.prototype.stop.apply(this);
-  this.contentService.unsubscribe();
+  this.contentService.unsubscribe(this.source.keywords);
 };
 
 module.exports = SubscribeBot;

--- a/lib/fetching/content-services/smsgh-content-service.js
+++ b/lib/fetching/content-services/smsgh-content-service.js
@@ -3,6 +3,7 @@
 var express = require('express');
 var ContentService = require('../content-service');
 var util = require('util');
+var _ = require('underscore');
 
 function SMSGhContentService(port) {
   this.fetchType = 'subscribe';
@@ -27,11 +28,10 @@ function SMSGhContentService(port) {
   this.port = port || 1111;
 }
 
-
 util.inherits(SMSGhContentService, ContentService);
 
 SMSGhContentService.prototype.subscribe = function(identifier) {
-  if (!(this._connectedSources.indexOf(identifier) > -1)) {
+  if (!(_.contains(this._connectedSources, identifier))) {
     this._connectedSources.push(identifier);
   }
   if (this._isListening) {
@@ -43,14 +43,14 @@ SMSGhContentService.prototype.subscribe = function(identifier) {
 };
 
 SMSGhContentService.prototype.unsubscribe = function(identifier) {
-  if (this._connectedSources.indexOf(identifier) > -1) {
+  if (_.contains(this._connectedSources, identifier)) {
     this._connectedSources.splice(this._connectedSources.indexOf(identifier), 1);
   } else {
-    throw new Error('Unsubscribe called even though the ' + identifier + 'content service is not subscribed');
+    self.emit('warning', new Error('Unsubscribe called even though the ' + identifier + 'bot is not subscribed'));
   }
   if (this._connectedSources.length === 0) {
-    this.server.close();
     this._isListening = false;
+    this.server.close();
   }
   return;
 };

--- a/lib/fetching/content-services/smsgh-content-service.js
+++ b/lib/fetching/content-services/smsgh-content-service.js
@@ -31,7 +31,6 @@ function SMSGhContentService(port) {
 util.inherits(SMSGhContentService, ContentService);
 
 SMSGhContentService.prototype.subscribe = function(identifier) {
-  this.counter += 1;
   if (!(this._connectedSources.indexOf(identifier) > -1)) {
     this._connectedSources.push(identifier);
   }
@@ -46,7 +45,6 @@ SMSGhContentService.prototype.subscribe = function(identifier) {
 SMSGhContentService.prototype.unsubscribe = function(identifier) {
   if (this._connectedSources.indexOf(identifier) > -1) {
     this._connectedSources.splice(this._connectedSources.indexOf(identifier), 1);
-    this.counter -= 1;
   } else {
     throw new Error('Unsubscribe called even though the ' + identifier + 'content service is not subscribed');
   }

--- a/lib/fetching/content-services/smsgh-content-service.js
+++ b/lib/fetching/content-services/smsgh-content-service.js
@@ -8,6 +8,7 @@ function SMSGhContentService(port) {
   this.fetchType = 'subscribe';
   this._isListening = false;
   this._app = express();
+  this._connectedSources = [];
   var self = this;
 
   var getKeyword = function(req) {
@@ -30,21 +31,30 @@ function SMSGhContentService(port) {
 util.inherits(SMSGhContentService, ContentService);
 
 SMSGhContentService.prototype.subscribe = function(identifier) {
+  this.counter += 1;
+  if (!(this._connectedSources.indexOf(identifier) > -1)) {
+    this._connectedSources.push(identifier);
+  }
   if (this._isListening) {
     return 'sms_ghana:' + identifier;
   }
   this._isListening = true;
   this.server = this._app.listen(this.port);
   return 'sms_ghana:' + identifier;
-
-// TODO: Modify to have a list of sources subscribed, so double unsubscribe doesn't happen
 };
 
-SMSGhContentService.prototype.unsubscribe = function() {
+SMSGhContentService.prototype.unsubscribe = function(identifier) {
+  if (this._connectedSources.indexOf(identifier) > -1) {
+    this._connectedSources.splice(this._connectedSources.indexOf(identifier), 1);
+    this.counter -= 1;
+  } else {
+    throw new Error('Unsubscribe called even though the ' + identifier + 'content service is not subscribed');
+  }
+  if (this._connectedSources.length === 0) {
+    this.server.close();
+    this._isListening = false;
+  }
   return;
-
-// TODO: Add server.close() when all sources unsubscribe.
-
 };
 
 SMSGhContentService.prototype._parse = function(query) {

--- a/lib/fetching/content-services/smsgh-content-service.js
+++ b/lib/fetching/content-services/smsgh-content-service.js
@@ -31,7 +31,7 @@ function SMSGhContentService(port) {
 util.inherits(SMSGhContentService, ContentService);
 
 SMSGhContentService.prototype.subscribe = function(identifier) {
-  if (!(_.contains(this._connectedSources, identifier))) {
+  if (!_.contains(this._connectedSources, identifier)) {
     this._connectedSources.push(identifier);
   }
   if (this._isListening) {
@@ -44,9 +44,9 @@ SMSGhContentService.prototype.subscribe = function(identifier) {
 
 SMSGhContentService.prototype.unsubscribe = function(identifier) {
   if (_.contains(this._connectedSources, identifier)) {
-    this._connectedSources.splice(this._connectedSources.indexOf(identifier), 1);
+    this._connectedSources = _.without(this._connectedSources, identifier);
   } else {
-    self.emit('warning', new Error('Unsubscribe called even though the ' + identifier + 'bot is not subscribed'));
+    this.emit('warning', new Error('Unsub() called though the ' + identifier + 'bot is not subscribed'));
   }
   if (this._connectedSources.length === 0) {
     this._isListening = false;

--- a/test/backend/lib.fetching.content-services.smsgh-content-service.test.js
+++ b/test/backend/lib.fetching.content-services.smsgh-content-service.test.js
@@ -42,7 +42,7 @@ describe('SMSGhana content service', function() {
     });
 
     afterEach(function() {
-      service.unsubscribe();
+      service.unsubscribe('dummy');
     });
 
     it('should start the server and send 200 code', function(done) {
@@ -73,8 +73,8 @@ describe('SMSGhana content service', function() {
           return done();
         });
 
-      service.unsubscribe();
-      service.unsubscribe();
+      service.unsubscribe('dodo');
+      service.unsubscribe('bozo');
     });
 
     it('should generate reports for each new source correctly', function(done) {
@@ -136,15 +136,15 @@ describe('SMSGhana content service', function() {
             return done(err);
           }
         });
-        service.unsubscribe();
-        service.unsubscribe();
+        service.unsubscribe('dodo');
+        service.unsubscribe('bozo');
     });
 
     it('should remove one source but still listen to other sources', function(done) {
       service.subscribe('dodo');
       var bozoEventName = service.subscribe('bozo');
 
-      service.unsubscribe();
+      service.unsubscribe('bozo');
 
       async.parallel([
         function(callback) {
@@ -186,7 +186,7 @@ describe('SMSGhana content service', function() {
           }
         });
 
-      service.unsubscribe();
+      service.unsubscribe('dodo');
     });
 
 
@@ -204,9 +204,9 @@ describe('SMSGhana content service', function() {
       service.subscribe('dodo');
       service.subscribe('bozo');
 
-      service.unsubscribe();
-      service.unsubscribe();
-      service.unsubscribe();
+      service.unsubscribe('dummy');
+      service.unsubscribe('dodo');
+      service.unsubscribe('bozo');
 
       request('http://localhost:1111')
         .get('/smsghana')


### PR DESCRIPTION
smsgh-content-service's unsubscribe function now closes the server when no sources are subscribed. It also throws a warning when unsubscribe() is called for a source that isn't subscribed in the first place.
The test has been modified accordingly (argument passed to the unsubscribe function), and all tests are now passing.