### PR TITLE
4496: Specific facebook error codes emit warnings rather than errors

### DIFF
--- a/lib/fetching/content-services/facebook-content-service.js
+++ b/lib/fetching/content-services/facebook-content-service.js
@@ -41,6 +41,9 @@ var graph = require('fbgraph');
 var util = require('util');
 var _ = require('underscore');
 
+// From https://developers.facebook.com/docs/graph-api/using-graph-api/#errors
+var transientErrorCodes = [1, 2, 4, 17, 341];
+
 // options.url - The url of the Facebook resource
 // options.lastReportDate - The time of the last report already fetched (optional)
 var FacebookContentService = function(options) {
@@ -82,9 +85,21 @@ FacebookContentService.prototype._doFetch = function(options, callback) {
     return;
   }
 
+  var isTransient = function(error) {
+    if (error.code && _.contains(transientErrorCodes, error.code)) {
+      return true;
+    }
+    return false;
+  };
+
   this._doRequest(source, function(err, data) {
     if (err) {
-      self.emit('error', new Error(err.message));
+      var level = 'error';
+      if (isTransient(err)) level = 'warning';
+      process.nextTick(function() {
+        self.emit(level, new Error(err.message));
+      });
+
       return callback([]);
     }
     callback(self._handleResults(data));

--- a/test/backend/fixtures/facebook-3.json
+++ b/test/backend/fixtures/facebook-3.json
@@ -1,0 +1,8 @@
+{
+		"message": "API Unknown",
+		"code": 1,
+		"error_subcode": 460,
+		"error_user_title": "A title",
+		"error_user_msg": "A message",
+		"fbtrace_id": "EJplcsCHuLu"
+}

--- a/test/backend/init.js
+++ b/test/backend/init.js
@@ -75,3 +75,12 @@ function expectToEmitError(listener, message, done) {
   });
 }
 module.exports.expectToEmitError = expectToEmitError;
+
+// Expect listener to emit warnings
+function expectToEmitWarning(listener, done) {
+  listener.once('warning', function(err) {
+    expect(err).to.be.an.instanceof(Error);
+    done();
+  });
+}
+module.exports.expectToEmitWarning = expectToEmitWarning;


### PR DESCRIPTION
A list of transient errors has been created from https://developers.facebook.com/docs/graph-api/using-graph-api/#errors. Experience may lead us to change that list as time evolves.

Comes with a test!