### PR TITLE
5102 A couple tests for the fetching toggling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ The following need to be installed.
 4. To run end-to-end tests:
   1. first start Aggie on the test database with `npm run testrun`
   2. then run protractor with `npm run protractor`
+5. To run end-to-end tests with external APIs
+  1. Set up the appropriate keys in `secrets.json` (e.g. Twitter)
+  2. start Aggie on the test database with `npm run testrun`
+  3. run protractor with `npm run protractor-with-apis`
 
 ## Project Configuration
 You can adjust the settings in the `config/secrets.json` file to configure the application.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 
     "testrun": "MONGO_AGGIE_DB=aggie-test node app.js",
     "preprotractor": "webdriver-manager update",
-    "protractor": "protractor test/end-to-end/protractor.conf.js"
+    "protractor": "protractor test/end-to-end/protractor.conf.js",
+    "protractor-with-apis": "protractor test/end-to-end/with-apis/protractor.conf.js"
   },
   "dependencies": {
     "angular-cookies": "~1.2.29",

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -135,6 +135,9 @@ module.exports.toggleSource = function(sourceName, state) {
   return;
 };
 
+// Returns an array for the first page of reports. If `pluckColumn` is set,
+// the elements of the array are just the text from that column. Otherwise, they
+// are the WebDriver elements for each row.
 module.exports.getReports = function(pluckColumn) {
   browser.get(browser.baseUrl + 'reports');
   var x = by.repeater("r in visibleReports.toArray() | orderBy:'-storedAt'");
@@ -144,6 +147,15 @@ module.exports.getReports = function(pluckColumn) {
   return element.all(x.column(pluckColumn)).map(function(elem) {
     return elem.getText();
   });
+};
+
+// Get the text from first span of the yellow stats bar
+module.exports.countAllReports = function() {
+  return element(by.css('.navbar-text > span'))
+           .getText()
+           .then(function(text) {
+             return Number(text);
+            });
 };
 
 module.exports.deleteSource = function(sourceName, nickname) {

--- a/test/end-to-end/with-apis/README.md
+++ b/test/end-to-end/with-apis/README.md
@@ -1,0 +1,9 @@
+End-to-end tests with connections to external APIs
+==================================================
+
+To run these tests, we need tokens for external APIs (e.g. Twitter). Set these
+up by setting up `secrets.json` appropriately. Then run the tests with
+
+```
+npm run protractor-with-apis
+```

--- a/test/end-to-end/with-apis/protractor.conf.js
+++ b/test/end-to-end/with-apis/protractor.conf.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.config = {
+  allScriptsTimeout: 11000,
+
+  specs: ['*.test.js'],
+
+  capabilities: {
+    browserName: 'chrome'
+  },
+
+  baseUrl: 'https://localhost:3000/',
+
+  framework: 'mocha',
+  mochaOpts: {
+    timeout: 20000,
+    slow: 2000
+  }
+};

--- a/test/end-to-end/with-apis/source-fetching-toggle.twitter.test.js
+++ b/test/end-to-end/with-apis/source-fetching-toggle.twitter.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var utils = require('../e2e-tools');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+var promise = protractor.promise;
+
+// Allow chai to wait for promises on the right-hand-side
+chaiAsPromised.transformAsserterArgs = function(args) {
+ return promise.all(args);
+};
+
+describe('Fetching toggle', function() {
+  before(utils.initDb);
+  after(utils.disconnectDropDb);
+
+  beforeEach(utils.resetDb);
+  beforeEach(utils.initAdmin.bind({}, 'asdfasdf'));
+  beforeEach(utils.toggleFetching.bind({}, 'Off'));
+  beforeEach(utils.addSource.bind({}, 'Twitter', { keywords: 'twitter' }));
+
+  afterEach(utils.deleteSource.bind({}, 'Twitter', 'Twitter Search'));
+  afterEach(utils.toggleFetching.bind({}, 'Off'));
+  afterEach(utils.resetBrowser);
+
+  it('should not collect reports when fetching is off', function() {
+    this.slow(2500);
+    browser.sleep(1000);
+    return expect(utils.countAllReports()).to.eventually.equal(0);
+  });
+
+  it('should collect reports when fetching is on', function() {
+    this.slow(7000);
+    utils.toggleFetching('On');
+    browser.sleep(1000);
+    return expect(utils.countAllReports()).to.eventually.be.at.least(1);
+  });
+
+  it('should not collect reports when fetching is on and sources are off', function() {
+    this.slow(8000);
+    utils.toggleSource('Twitter', 'Off');
+    utils.toggleFetching('On');
+    browser.sleep(1000);
+    return expect(utils.countAllReports()).to.eventually.equal(0);
+  });
+
+  it('should not collect reports when sources are off and fetching is flipped', function() {
+    this.slow(15000);
+    utils.toggleFetching('On');
+    browser.sleep(1000);
+    utils.toggleSource('Twitter', 'Off');
+    utils.toggleFetching('Off');
+    browser.sleep(500);
+    var count1 = utils.countAllReports();
+    utils.toggleFetching('On');
+    browser.sleep(2000);
+    var count2 = utils.countAllReports();
+    var e1 = expect(count1).to.eventually.be.at.least(1);
+    var e2 = expect(count1).to.eventually.equal(count2);
+    return promise.all([e1, e2]);
+  });
+});


### PR DESCRIPTION
These tests require access to the Twitter API, so we've added a new
command `npm run protractor-with-apis` which is documented in
`test/end-to-end/with-apis/README.md`.

Four tests are added here. The first two are passing, and the second two
are failing.

These tests all pass on the current 5102_fetching_reliability:
```
git checkout 4544ab9c2
git cherry-pick 6f5c896
npm i
npm run testrun &
npm run protractor-with-apis
```