### PR TITLE
1927 remove Mongo text search

### DIFF
--- a/lib/analytics/trend-queryer.js
+++ b/lib/analytics/trend-queryer.js
@@ -4,14 +4,17 @@
 var Trend = require('../../models/trend');
 var ReportQuery = require('../../models/query/report-query');
 var Report = require('../../models/report');
-var _ = require('underscore');
+var _ = require('lodash');
+var logger = require('../logger');
 
 var TrendQueryer = function(options) {
   this.trend = options.trend;
   try {
     // Parse serialized query object and instantiate it
     this.query = new ReportQuery(JSON.parse(this.trend._query));
-  } catch (e) {}
+  } catch (err) {
+    logger.log(err);
+  }
 };
 
 // Query database and calculate trends
@@ -37,22 +40,16 @@ TrendQueryer.prototype.runQuery = function(callback) {
 // Analyze trends for a given keyword
 TrendQueryer.prototype.analyzeTrend = function(callback) {
   var self = this;
-  var options = this._parseQueryOptions(this.query);
+  var filter = this._toMongooseFilter(this.query);
 
   // Re-set search timestamp
   this.query.since = new Date();
 
-  if (!this.query.keywords) {
-    // Just use filters when no keywords are provided
-    Report.find(options.filter, function(err, reports) {
-      if (err) return callback(err);
-      var timeboxes = self.countTimeboxes(reports);
-      callback(null, timeboxes);
-    });
-  } else {
-    // Run report analysis
-    this.runReportAnalysis(this.query.keywords, options, callback);
-  }
+  Report.find(filter, function(err, reports) {
+    if (err) return callback(err);
+    var timeboxes = self.countTimeboxes(reports);
+    callback(null, timeboxes);
+  });
 };
 
 TrendQueryer.prototype.countTimeboxes = function(reports) {
@@ -64,22 +61,6 @@ TrendQueryer.prototype.countTimeboxes = function(reports) {
     // Count matching reports per timebox
     return { timebox: timebox, counts: counts };
   }).value();
-};
-
-// Search for reports to run analysis
-TrendQueryer.prototype.runReportAnalysis = function(keywords, options, callback) {
-  var self = this;
-  Report.textSearch(keywords, options, function(err, reports) {
-    if (err) return callback(err);
-    var trends = _.chain(reports.results).pluck('obj').map(function(report) {
-      // Get timebox for each report
-      return self.getTimebox(report);
-    }).countBy('timebox').map(function(counts, timebox) {
-      // Count matching reports per timebox
-      return { timebox: timebox, counts: counts };
-    }).value();
-    callback(null, trends);
-  });
 };
 
 // Calculate timebox
@@ -112,48 +93,33 @@ TrendQueryer.prototype.backFill = function(callback) {
   var query = _.clone(this.query);
   query.since = new Date(Date.now - (60 * 60 * 4 * 1000)); // 4 hours ago
   query.until = new Date();
-  var options = this._parseQueryOptions(query);
+  var filter = this._toMongooseFilter(query);
 
-  if (!query.keywords) {
-    // Just use filters when no keywords are provided
-    Report.find(options.filter, function(err, reports) {
-      if (err) return callback(err);
-      var trends = self.countTimeboxes(reports);
-      if (!trends.length) return callback(null, []);
-      // Sort by timebox
-      trends = _.sortBy(trends, 'timebox');
-      // Store trend counts in trend model
-      self.updateTrends(trends, callback);
-    });
-  } else {
-    // Run trend analysis since the earliest time
-    this.runReportAnalysis(query.keywords, options, function(err, trends) {
-      if (err) return callback(err);
-      if (!trends.length) return callback(null, []);
-      // Sort by timebox
-      trends = _.sortBy(trends, 'timebox');
-      // Store trend counts in trend model
-      self.updateTrends(trends, callback);
-    });
-  }
+  // Just use filters when no keywords are provided
+  Report.find(filter, function(err, reports) {
+    if (err) return callback(err);
+    var trends = self.countTimeboxes(reports);
+    if (!trends.length) return callback(null, []);
+    // Sort by timebox
+    trends = _.sortBy(trends, 'timebox');
+    // Store trend counts in trend model
+    self.updateTrends(trends, callback);
+  });
 };
 
 // Convert query into searchable options
-TrendQueryer.prototype._parseQueryOptions = function(query) {
-  var options = {
-    filter: { storedAt: { $gte: query.since || this.trend.lastEnabledAt } },
-    limit: 999999,
-    lean: true
-  };
+TrendQueryer.prototype._toMongooseFilter = function(query) {
+  var filter = { storedAt: { $gte: query.since || this.trend.lastEnabledAt } };
 
-  if (query.until) options.filter.storedAt.$lt = query.until;
+  if (query.until) filter.storedAt.$lt = query.until;
+  if (query.keywords) filter.$text = { $search: query.keywords };
 
   // Convert reference fields for Report compatibility
-  if (query.sourceId) options.filter._source = query.sourceId;
-  if (query.media) options.filter._media = query.media;
-  if (query.incidentId) options.filter._incident = query.incidentId;
+  if (query.sourceId) filter._source = query.sourceId;
+  if (query.media) filter._media = query.media;
+  if (query.incidentId) filter._incident = query.incidentId;
 
-  return options;
+  return filter;
 };
 
 module.exports = TrendQueryer;

--- a/models/report.js
+++ b/models/report.js
@@ -4,7 +4,6 @@
 
 var database = require('../lib/database');
 var mongoose = database.mongoose;
-var textSearch = require('mongoose-text-search');
 var listenTo = require('mongoose-listento');
 var Schema = mongoose.Schema;
 
@@ -26,7 +25,6 @@ var schema = new Schema({
 });
 
 // Give the report schema text search capabilities
-schema.plugin(textSearch);
 schema.plugin(listenTo);
 
 // Add fulltext index to the `content` field.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3100,11 +3100,6 @@
         }
       }
     },
-    "mongoose-text-search": {
-      "version": "0.0.2",
-      "from": "mongoose-text-search@0.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-text-search/-/mongoose-text-search-0.0.2.tgz"
-    },
     "mongoose-validator": {
       "version": "1.2.5",
       "from": "mongoose-validator@>=1.2.4 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mongoose": "~3.8.23",
     "mongoose-auto-increment": "^3.2.0",
     "mongoose-listento": "0.0.4",
-    "mongoose-text-search": "0.0.2",
     "mongoose-validator": "^1.2.4",
     "nconf": "~0.7.1",
     "node-sass": "~0.8.6",


### PR DESCRIPTION
The very old `mongoose-text-search` plugin was using deprecated functionality in mongo. Now it's gone and we're closer to being able to upgrade mongo.

This is created from the 5052 branch, which took the first step of removing some of our calls to the text search plugin.