### PR TITLE
4803: Sources switch back to 'Off' after every warning

### DIFF
--- a/lib/fetching/bot.js
+++ b/lib/fetching/bot.js
@@ -34,6 +34,7 @@ util.inherits(Bot, EventEmitter);
 Bot.prototype.start = function() {
   if (this.enabled) return;
   this.enabled = true;
+  this.source.enabled = true;
   this.contentService.on(this.incomingEventName, this._reportListener);
   this.contentService.on('warning', this._warningListener);
   this.contentService.on('error', this._errorListener);
@@ -55,6 +56,7 @@ Bot.prototype.logDrops = function() {
 
 Bot.prototype.stop = function() {
   this.enabled = false;
+  this.source.enabled = false;
   this.contentService.removeListener(this.incomingEventName, this._reportListener);
   this.contentService.removeListener('warning', this._warningListener);
   this.contentService.removeListener('error', this._errorListener);

--- a/test/end-to-end/with-apis/source-fetching-toggle.twitter.test.js
+++ b/test/end-to-end/with-apis/source-fetching-toggle.twitter.test.js
@@ -35,7 +35,7 @@ describe('Fetching toggle', function() {
   it('should collect reports when fetching is on', function() {
     this.slow(7000);
     utils.toggleFetching('On');
-    browser.sleep(1000);
+    browser.sleep(3000);
     return expect(utils.countAllReports()).to.eventually.be.at.least(1);
   });
 


### PR DESCRIPTION
When a bot is stopped, it alters the 'enabled' flag in its source object. This (somehow) is accessed by the sources in the 'Sources' page, and when a source errors and its bot is stopped, the Source state toggles to 'off'.