### PR TITLE
4803 When sources error, the fetching button turns off

### DIFF
--- a/lib/fetching/bot.js
+++ b/lib/fetching/bot.js
@@ -116,7 +116,9 @@ Bot.prototype._errorListener = function(error) {
 Bot.prototype._handleError = function(type, error) {
   var message = error instanceof Error ? error.message : error;
 
-  this.source.logEvent(type, message);
+  this.source.logEvent(type, message, function(err) {
+    if (err) logger.error(err.message);
+  });
   logger[type](error);
 };
 

--- a/models/source.js
+++ b/models/source.js
@@ -68,11 +68,13 @@ sourceSchema.pre('save', function(next) {
 });
 
 sourceSchema.post('save', function() {
+  if (!this._silent) {
+    sourceSchema.emit('source:save', { _id: this._id.toString() });
+  }
+
   if (this._sourceStatusChanged) {
-    var event = (this.enabled) ? 'source:enable' : 'source:disable';
+    var event = this.enabled ? 'source:enable' : 'source:disable';
     sourceSchema.emit(event, { _id: this._id.toString() });
-  } else {
-    if (!this._silent) sourceSchema.emit('source:save', { _id: this._id.toString() });
   }
 
   if (this._sourceErrorCountUpdated) {

--- a/public/angular/js/controllers/sources/index.js
+++ b/public/angular/js/controllers/sources/index.js
@@ -17,12 +17,6 @@ angular.module('Aggie')
       });
     };
 
-    $scope.refresh = function() {
-      Source.query(function(sources) {
-        $scope.sources = sources;
-      });
-    };
-
     $scope.target = function(source) {
       return source.media == 'twitter' || source.media == 'smsgh' ? source.keywords : source.url;
     };

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -167,3 +167,40 @@ module.exports.deleteSource = function(sourceName, nickname) {
   element(by.buttonText('Delete')).click();
   return element(by.buttonText('Confirm')).click();
 };
+
+module.exports.getWarningCount = function(sourceName) {
+  var sourceIconMapping = {
+    Twitter: 'twitter-source',
+    Facebook: 'facebook-source',
+    RSS: 'rss-source',
+    Elmo: 'elmo-source',
+    'SMS GH': 'smsgh-source'
+  };
+  browser.get(browser.baseUrl + 'sources');
+  return element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
+           .element(by.xpath('..'))
+           .element(by.css('[ng-class="{ \'multiple-errors\': s.unreadErrorCount > 0 }"]'))
+           .getText()
+           .then(function(text) {
+             return Number(text);
+           });
+};
+
+module.exports.checkSourceState = function(sourceName) {
+  var sourceIconMapping = {
+    Twitter: 'twitter-source',
+    Facebook: 'facebook-source',
+    RSS: 'rss-source',
+    Elmo: 'elmo-source',
+    'SMS GH': 'smsgh-source'
+  };
+  browser.get(browser.baseUrl + 'sources');
+  return element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
+           .element(by.xpath('..'))
+           .element(by.css('[class="toggle-item ng-scope ng-binding selected"]'))
+           .getText()
+           .then(function(text) {
+             return text;
+           });
+
+};

--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -124,14 +124,16 @@ module.exports.toggleFetching = function(state) {
   return element(by.css('[ng-click="toggle(' + stateMapping[state] + ')"]')).click();
 };
 
+var sourceIconMapping = {
+  Twitter: 'twitter-source',
+  Facebook: 'facebook-source',
+  RSS: 'rss-source',
+  Elmo: 'elmo-source',
+  'SMS GH': 'smsgh-source'
+};
+module.exports.sourceIconMapping = sourceIconMapping;
+
 module.exports.toggleSource = function(sourceName, state) {
-  var sourceIconMapping = {
-    Twitter: 'twitter-source',
-    Facebook: 'facebook-source',
-    RSS: 'rss-source',
-    Elmo: 'elmo-source',
-    'SMS GH': 'smsgh-source'
-  };
   browser.get(browser.baseUrl + 'sources');
   return element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
     .element(by.xpath('..'))
@@ -169,13 +171,6 @@ module.exports.deleteSource = function(sourceName, nickname) {
 };
 
 module.exports.getWarningCount = function(sourceName) {
-  var sourceIconMapping = {
-    Twitter: 'twitter-source',
-    Facebook: 'facebook-source',
-    RSS: 'rss-source',
-    Elmo: 'elmo-source',
-    'SMS GH': 'smsgh-source'
-  };
   browser.get(browser.baseUrl + 'sources');
   return element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
            .element(by.xpath('..'))
@@ -187,20 +182,9 @@ module.exports.getWarningCount = function(sourceName) {
 };
 
 module.exports.checkSourceState = function(sourceName) {
-  var sourceIconMapping = {
-    Twitter: 'twitter-source',
-    Facebook: 'facebook-source',
-    RSS: 'rss-source',
-    Elmo: 'elmo-source',
-    'SMS GH': 'smsgh-source'
-  };
   browser.get(browser.baseUrl + 'sources');
   return element(by.css('[class="compact source ' + sourceIconMapping[sourceName] + '"]'))
            .element(by.xpath('..'))
            .element(by.css('[class="toggle-item ng-scope ng-binding selected"]'))
-           .getText()
-           .then(function(text) {
-             return text;
-           });
-
+           .getText();
 };

--- a/test/end-to-end/with-apis/facebook-error.test.js
+++ b/test/end-to-end/with-apis/facebook-error.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var utils = require('../e2e-tools');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+var promise = protractor.promise;
+
+// Allow chai to wait for promises on the right-hand-side
+chaiAsPromised.transformAsserterArgs = function(args) {
+  return promise.all(args);
+};
+
+describe('Facebook source error', function() {
+  before(utils.initDb);
+  after(utils.disconnectDropDb);
+
+  beforeEach(utils.resetDb);
+  beforeEach(utils.initAdmin.bind({}, 'asdfasdf'));
+  beforeEach(utils.toggleFetching.bind({}, 'Off'));
+  beforeEach(utils.addSource.bind({}, 'Facebook', { nickname: 'test', url: 'https://www.facebook.com/jkfajklwertwerja' }));
+  beforeEach(utils.toggleFetching.bind({}, 'On'));
+
+  afterEach(utils.deleteSource.bind({}, 'Facebook', 'test'));
+  afterEach(utils.toggleFetching.bind({}, 'Off'));
+  afterEach(utils.resetBrowser);
+
+  it('source should show "Off" when a source errors', function() {
+    var e1 = expect(utils.getWarningCount('Facebook')).to.eventually.equal(1);
+    var s1 = expect(utils.checkSourceState('Facebook')).to.eventually.equal('OFF');
+    utils.toggleSource('Facebook', 'On');
+    var e2 = expect(utils.getWarningCount('Facebook')).to.eventually.equal(2);
+    var s2 = expect(utils.checkSourceState('Facebook')).to.eventually.equal('OFF');
+    return promise.all([e1, e2, s1, s2]);
+  });
+});


### PR DESCRIPTION
The source schema in the fetching process gets out of date when clicking
'On' or 'Off' from `/sources`. Only the `source:save` event triggers
reloading the source, not `source:enable` or `source:disable`. Now we
emit `source:save` whenever a source is saved.

Two other changes here that I ran into
 * in `bot.js`, `logEvent` sends its errors to the
   callback, which should not be ignored.
 * `$scope.refresh` from `SourcesIndexController` is not used anywhere