### PR TITLE
Current e2e tests choose the first element (where applicable) explicitly

### DIFF
--- a/test/end-to-end/e2e-tools.js
+++ b/test/end-to-end/e2e-tools.js
@@ -40,7 +40,7 @@ module.exports.initAdmin = function(password) {
 module.exports.logOut = function() {
   // Note: it would be nice if there were a more reliable way to get the logout
   // button.
-  element(by.cssContainingText('li a', 'Log out')).click();
+  element.all(by.cssContainingText('li a', 'Log out')).first().click();
   return expect(browser.getCurrentUrl()).to.eventually.equal(browser.baseUrl + 'login');
 };
 
@@ -89,7 +89,7 @@ module.exports.setFilter = function(filter) {
     clickClearSend(by.model('times.after'), filter.time.after);
     element(by.buttonText('Submit')).click();
   }
-  element(by.buttonText('Go')).click();
+  element.all(by.buttonText('Go')).first().click();
   return e;
 };
 
@@ -103,7 +103,7 @@ module.exports.addSource = function(sourceName, params) {
   };
   browser.get(browser.baseUrl + 'sources');
   element(by.buttonText('Create Source')).click();
-  element(by.model('source.media')).$('[value="' + sourceList[sourceName] + '"]').click();
+  element.all(by.model('source.media')).first().$('[value="' + sourceList[sourceName] + '"]').click();
   if (sourceName !== 'Twitter') {
     element(by.model('source.nickname')).sendKeys(params.nickname ? params.nickname : 'blank');
   }
@@ -154,7 +154,7 @@ module.exports.getReports = function(pluckColumn) {
 
 // Get the text from first span of the yellow stats bar
 module.exports.countAllReports = function() {
-  return element(by.css('.navbar-text > span'))
+  return element.all(by.css('.navbar-text > span')).first()
            .getText()
            .then(function(text) {
              return Number(text);

--- a/test/end-to-end/source-fetching-toggle.test.js
+++ b/test/end-to-end/source-fetching-toggle.test.js
@@ -9,7 +9,7 @@ var expect = chai.expect;
 var promise = protractor.promise;
 
 
-describe('test duplication of reports with different settings', function() {
+describe('test generation of reports', function() {
   before(utils.initDb);
   after(utils.disconnectDropDb);
 
@@ -54,19 +54,19 @@ describe('test duplication of reports with different settings', function() {
     };
   };
 
-  it('should listen with fetching:on and source:enabled',
+  it('with fetching:on and source:enabled',
      setAndExpect(true, true, 1));
 
-  it('should not listen with fetching:on and source:disabled',
+  it('with fetching:on and source:disabled',
      setAndExpect(true, false, 0));
 
-  it('should not listening wtih fetching:off and source:enabled',
+  it('wtih fetching:off and source:enabled',
      setAndExpect(false, true, 0));
 
-  it('should not listen with fetching:off and source:disabled',
+  it('with fetching:off and source:disabled',
      setAndExpect(false, false, 0));
 
-  it('should not listen with fetching toggled from on to off and source:disabled', function() {
+  it('with fetching toggled from on to off and source:disabled', function() {
     utils.toggleFetching('On');
     setAndExpect(false, false, 0)();
   });


### PR DESCRIPTION
This prevents warnings from cluttering the terminal window where the tests are running.