### PR TITLE
5326: Added tags to Incident schema as an array of strings

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -26,6 +26,7 @@ var schema = new mongoose.Schema({
   longitude: Number,
   updatedAt: Date,
   storedAt: Date,
+  tags: { type: [String], default: [] },
   assignedTo: { type: mongoose.Schema.ObjectId, ref: 'User' },
   creator: { type: mongoose.Schema.ObjectId, ref: 'User' },
   status: { type: String, default: 'new', required: true },

--- a/test/backend/lib.api.v1.incident-controller.test.js
+++ b/test/backend/lib.api.v1.incident-controller.test.js
@@ -24,6 +24,7 @@ describe('Incident controller', function() {
           expect(res.body).to.have.property('updatedAt');
           expect(res.body).to.have.property('status');
           expect(res.body).to.have.property('veracity');
+          expect(res.body).to.have.property('tags');
           incident._id = res.body._id;
           utils.compare(res.body, incident);
           done();


### PR DESCRIPTION
Proposal for tag field in schema
Simple array of strings. It should be easy and fast to search through them.
We don't know how we are going to get tags passed by the front end to the IncidentQuery, and some though and tests are required at both ends.