### PR TITLE
5330: Filtering incidents by tags

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -142,6 +142,17 @@ Incident.queryIncidents = function(query, page, options, callback) {
   if (query.locationName) filter.locationName = new RegExp(query.locationName, 'i');
   else delete filter.locationName;
 
+  // Checking for multiple tags in incident
+  if (query.tags) {
+    tags = [];
+    for (var i = 0; i < query.tags.length; i++) {
+      tags[i] = new RegExp(query.tags[i], 'i');
+    }
+    filter.tags = {};
+    filter.tags.$in = tags;
+  }
+  else delete filter.tags;
+
   // Re-set search timestamp
   query.since = new Date();
 

--- a/models/incident.js
+++ b/models/incident.js
@@ -2,10 +2,10 @@
 // It is generally associated with one or more reports.
 // Other metadata is stored with the incident to assist tracking.
 // This class is responsible for executing IncidentQuerys.
+'use strict';
 
 var database = require('../lib/database');
 var mongoose = database.mongoose;
-var Schema = mongoose.Schema;
 var validate = require('mongoose-validator');
 var _ = require('underscore');
 var autoIncrement = require('mongoose-auto-increment');
@@ -15,13 +15,13 @@ var logger = require('../lib/logger');
 
 require('../lib/error');
 
-var length_validator = validate({
+var lengthValidator = validate({
   validator: 'isLength',
   arguments: [0, 32]
 });
 
 var schema = new mongoose.Schema({
-  title: { type: String, required: true, validate: length_validator },
+  title: { type: String, required: true, validate: lengthValidator },
   locationName: String,
   latitude: Number,
   longitude: Number,
@@ -123,18 +123,18 @@ Incident.queryIncidents = function(query, page, options, callback) {
     filter.storedAt.$gte = query.since;
   }
 
-  if (query.veracity == 'confirmed true') filter.veracity = true;
-  if (query.veracity == 'confirmed false') filter.veracity = false;
-  if (query.veracity == 'unconfirmed') filter.veracity = null;
+  if (query.veracity === 'confirmed true') filter.veracity = true;
+  if (query.veracity === 'confirmed false') filter.veracity = false;
+  if (query.veracity === 'unconfirmed') filter.veracity = null;
   if (_.isBoolean(query.veracity)) filter.veracity = query.veracity;
 
-  if (query.status == 'open') filter.closed = false;
-  if (query.status == 'closed') filter.closed = true;
+  if (query.status === 'open') filter.closed = false;
+  if (query.status === 'closed') filter.closed = true;
   delete filter.status;
   if (_.isBoolean(query.closed)) filter.closed = query.closed;
 
-  if (query.escalated == 'escalated') filter.escalated = true;
-  if (query.escalated == 'unescalated') filter.escalated = false;
+  if (query.escalated === 'escalated') filter.escalated = true;
+  if (query.escalated === 'unescalated') filter.escalated = false;
 
   // Search for substrings
   if (query.title) filter.title = new RegExp(query.title, 'i');
@@ -144,14 +144,13 @@ Incident.queryIncidents = function(query, page, options, callback) {
 
   // Checking for multiple tags in incident
   if (query.tags) {
-    tags = [];
+    var tags = [];
     for (var i = 0; i < query.tags.length; i++) {
-      tags[i] = new RegExp(query.tags[i], 'i');
+      tags[i] = query.tags[i];
     }
     filter.tags = {};
     filter.tags.$in = tags;
-  }
-  else delete filter.tags;
+  } else delete filter.tags;
 
   // Re-set search timestamp
   query.since = new Date();
@@ -162,7 +161,7 @@ Incident.queryIncidents = function(query, page, options, callback) {
 
 // Mixin shared incident methods
 var Shared = require('../shared/incident');
-for (var static in Shared) Incident[static] = Shared[static];
+for (var staticVar in Shared) Incident[staticVar] = Shared[staticVar];
 for (var proto in Shared.prototype) schema.methods[proto] = Shared[proto];
 
 module.exports = Incident;

--- a/models/incident.js
+++ b/models/incident.js
@@ -2,6 +2,7 @@
 // It is generally associated with one or more reports.
 // Other metadata is stored with the incident to assist tracking.
 // This class is responsible for executing IncidentQuerys.
+/* eslint-disable no-invalid-this */
 'use strict';
 
 var database = require('../lib/database');

--- a/models/incident.js
+++ b/models/incident.js
@@ -144,12 +144,7 @@ Incident.queryIncidents = function(query, page, options, callback) {
 
   // Checking for multiple tags in incident
   if (query.tags) {
-    var tags = [];
-    for (var i = 0; i < query.tags.length; i++) {
-      tags[i] = query.tags[i];
-    }
-    filter.tags = {};
-    filter.tags.$in = tags;
+    filter.tags = { $in: query.tags };
   } else delete filter.tags;
 
   // Re-set search timestamp

--- a/models/query/incident-query.js
+++ b/models/query/incident-query.js
@@ -13,6 +13,7 @@ var IncidentQuery = function(options) {
   this.closed = options.status == 'closed';
   this.veracity = options.veracity == 'Confirmed true' ? true : (options.veracity == 'Confirmed false' ? false : null);
   this.event = 'incidents';
+  this.tags = options.tags;
 };
 
 _.extend(IncidentQuery, Query);

--- a/test/backend/models.query.incident-query.test.js
+++ b/test/backend/models.query.incident-query.test.js
@@ -15,10 +15,12 @@ describe('Incident query attributes', function() {
     Incident.remove(function(err) {
       if (err) return done(err);
       async.each([
-        { title: 'The quick brown fox', veracity: null, closed: true },
-        { title: 'The slow white fox', veracity: true, closed: false },
-        { title: 'The quick brown chicken', veracity: null, closed: false },
-        { title: 'The brown quick fox', veracity: false, closed: true }
+        { title: 'The quick brown fox', veracity: null, closed: true, tags: ['hello', 'world'] },
+        { title: 'The slow white fox', veracity: true, closed: false, tags: ['hello'] },
+        { title: 'The quick brown chicken', veracity: null, closed: false, tags: ['world'] },
+        { title: 'The brown quick fox', veracity: false, closed: true, tags: ['helloworld', 'wellohorld', 'foobar'] },
+        { title: 'The fox that was slow and brown', veracity: false, closed: true, tags: ['foobar', 'hello'] },
+        { title: 'The slow that was fox and brown', veracity: false, closed: true, tags: ['wellohorld', 'hello'] }
       ], Incident.create.bind(Incident), done);
     });
   });
@@ -89,6 +91,50 @@ describe('Incident query attributes', function() {
       expect(incidents.results).to.be.an.instanceof(Array);
       expect(incidents.results).to.have.length(1);
       expect(incidents.results[0].title).to.contain('quick');
+      done();
+    });
+  });
+
+  it('should query by single full tag', function(done) {
+    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['foobar'] })).run(function(err, incidents) {
+      if (err) return done(err);
+      expect(incidents).to.have.keys(['total', 'results']);
+      expect(incidents.total).to.equal(2);
+      expect(incidents.results).to.be.an.instanceof(Array);
+      expect(incidents.results).to.have.length(2);
+      done();
+    });
+  });
+
+  it('should query by single partial tag', function(done) {
+    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['ell'] })).run(function(err, incidents) {
+      if (err) return done(err);
+      expect(incidents).to.have.keys(['total', 'results']);
+      expect(incidents.total).to.equal(3);
+      expect(incidents.results).to.be.an.instanceof(Array);
+      expect(incidents.results).to.have.length(3);
+      done();
+    });
+  });
+
+    it('should query by multiple full tags', function(done) {
+    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['wellohorld', 'foobar'] })).run(function(err, incidents) {
+      if (err) return done(err);
+      expect(incidents).to.have.keys(['total', 'results']);
+      expect(incidents.total).to.equal(3);
+      expect(incidents.results).to.be.an.instanceof(Array);
+      expect(incidents.results).to.have.length(3);
+      done();
+    });
+  });
+
+  it('should query by multiple partial tags', function(done) {
+    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['llo', 'ooba'] })).run(function(err, incidents) {
+      if (err) return done(err);
+      expect(incidents).to.have.keys(['total', 'results']);
+      expect(incidents.total).to.equal(3);
+      expect(incidents.results).to.be.an.instanceof(Array);
+      expect(incidents.results).to.have.length(3);
       done();
     });
   });

--- a/test/backend/models.query.incident-query.test.js
+++ b/test/backend/models.query.incident-query.test.js
@@ -15,15 +15,62 @@ describe('Incident query attributes', function() {
     Incident.remove(function(err) {
       if (err) return done(err);
       async.each([
-        { title: 'The quick brown fox', veracity: null, closed: true, tags: ['hello', 'world'] },
-        { title: 'The slow white fox', veracity: true, closed: false, tags: ['hello'] },
-        { title: 'The quick brown chicken', veracity: null, closed: false, tags: ['world'] },
-        { title: 'The brown quick fox', veracity: false, closed: true, tags: ['helloworld', 'wellohorld', 'foobar'] },
-        { title: 'The fox that was slow and brown', veracity: false, closed: true, tags: ['foobar', 'hello'] },
-        { title: 'The slow that was fox and brown', veracity: false, closed: true, tags: ['wellohorld', 'hello'] }
+        {
+          title: 'The quick brown fox',
+          veracity: null,
+          closed: true,
+          tags: ['hello', 'world']
+        },
+        {
+          title: 'The slow white fox',
+          veracity: true,
+          closed: false,
+          tags: ['hello']
+        },
+        {
+          title: 'The quick brown chicken',
+          veracity: null,
+          closed: false,
+          tags: ['world']
+        },
+        {
+          title: 'The brown quick fox',
+          veracity: false,
+          closed: true,
+          tags: ['helloworld', 'wellohorld', 'foobar']
+        },
+        {
+          title: 'The fox that was slow and brown',
+          veracity: false,
+          closed: true,
+          tags: ['foobar', 'hello']
+        },
+        {
+          title: 'The slow that was fox and brown',
+          veracity: false,
+          closed: true,
+          tags: ['wellohorld', 'hello']
+        }
       ], Incident.create.bind(Incident), done);
     });
   });
+
+  var incidentTagTester = function(tags, n) {
+    return function(done) {
+      new IncidentQuery({
+        veracity: 'Confirmed false',
+        status: 'closed',
+        tags: tags
+      }).run(function(err, incidents) {
+        if (err) return done(err);
+        expect(incidents).to.have.keys(['total', 'results']);
+        expect(incidents.total).to.equal(n);
+        expect(incidents.results).to.be.an.instanceof(Array);
+        expect(incidents.results).to.have.length(n);
+        done();
+      });
+    };
+  };
 
   it('should normalize query', function() {
     var normalized = query.normalize();
@@ -95,27 +142,9 @@ describe('Incident query attributes', function() {
     });
   });
 
-  it('should query by single full tag', function(done) {
-    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['foobar'] })).run(function(err, incidents) {
-      if (err) return done(err);
-      expect(incidents).to.have.keys(['total', 'results']);
-      expect(incidents.total).to.equal(2);
-      expect(incidents.results).to.be.an.instanceof(Array);
-      expect(incidents.results).to.have.length(2);
-      done();
-    });
-  });
+  it('should query by single full tag', incidentTagTester(['foobar'], 2));
 
-  it('should query by multiple full tags', function(done) {
-    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['wellohorld', 'foobar'] })).run(function(err, incidents) {
-      if (err) return done(err);
-      expect(incidents).to.have.keys(['total', 'results']);
-      expect(incidents.total).to.equal(3);
-      expect(incidents.results).to.be.an.instanceof(Array);
-      expect(incidents.results).to.have.length(3);
-      done();
-    });
-  });
+  it('should query by multiple full tags', incidentTagTester(['wellohorld', 'foobar'], 3));
 
   after(utils.wipeModels([Incident]));
   after(utils.expectModelsEmpty);

--- a/test/backend/models.query.incident-query.test.js
+++ b/test/backend/models.query.incident-query.test.js
@@ -106,30 +106,8 @@ describe('Incident query attributes', function() {
     });
   });
 
-  it('should query by single partial tag', function(done) {
-    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['ell'] })).run(function(err, incidents) {
-      if (err) return done(err);
-      expect(incidents).to.have.keys(['total', 'results']);
-      expect(incidents.total).to.equal(3);
-      expect(incidents.results).to.be.an.instanceof(Array);
-      expect(incidents.results).to.have.length(3);
-      done();
-    });
-  });
-
-    it('should query by multiple full tags', function(done) {
+  it('should query by multiple full tags', function(done) {
     (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['wellohorld', 'foobar'] })).run(function(err, incidents) {
-      if (err) return done(err);
-      expect(incidents).to.have.keys(['total', 'results']);
-      expect(incidents.total).to.equal(3);
-      expect(incidents.results).to.be.an.instanceof(Array);
-      expect(incidents.results).to.have.length(3);
-      done();
-    });
-  });
-
-  it('should query by multiple partial tags', function(done) {
-    (new IncidentQuery({ veracity: 'Confirmed false', status: 'closed', tags: ['llo', 'ooba'] })).run(function(err, incidents) {
       if (err) return done(err);
       expect(incidents).to.have.keys(['total', 'results']);
       expect(incidents.total).to.equal(3);


### PR DESCRIPTION
Server-side code for filtering incidents by tags.
If a single tag is provided, all incidents with that tag are shown.
If multiple tags are provided, all incidents that contain `at least 1` of those tags are shown.