### PR TITLE
5327 add tag to incident

### DIFF
--- a/public/angular/.eslintrc.json
+++ b/public/angular/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "globals": {
+    "angular": false,
+    "Autolinker": false
+  }
+}

--- a/public/angular/js/app.js
+++ b/public/angular/js/app.js
@@ -91,6 +91,7 @@ require('./services/trend_fetching');
 require('./services/map');
 require('./services/batch');
 require('./services/api_modal');
+require('./services/tags');
 
 // Controllers
 require('./controllers/application');

--- a/public/angular/js/controllers/incidents/form_modal.js
+++ b/public/angular/js/controllers/incidents/form_modal.js
@@ -107,7 +107,9 @@ angular.module('Aggie')
   'users',
   'incident',
   'reports',
-  function($scope, $modalInstance, incidentStatusOptions, veracityOptions, users, incident, reports) {
+  'Tags',
+  function($scope, $modalInstance, incidentStatusOptions, veracityOptions,
+           users, incident, reports, Tags) {
     $scope.incident = angular.copy(incident);
     $scope.users = users;
     $scope.veracity = veracityOptions;
@@ -126,6 +128,7 @@ angular.module('Aggie')
 
       // Only send assignedTo _id, not whole object.
       $scope.incident.assignedTo = ($scope.incident.assignedTo || { _id: null })['_id'];
+      $scope.incident.tags = Tags.stringToTags($scope.incident.tags);
 
       $modalInstance.close($scope.incident);
     };

--- a/public/angular/js/controllers/incidents/index.js
+++ b/public/angular/js/controllers/incidents/index.js
@@ -15,7 +15,10 @@ angular.module('Aggie')
   'Socket',
   'Queue',
   'paginationOptions',
-  function($state, $scope, $rootScope, $stateParams, flash, incidents, users, incidentStatusOptions, veracityOptions, escalatedOptions, Incident, Socket, Queue, paginationOptions) {
+  'Tags',
+  function($state, $scope, $rootScope, $stateParams, flash, incidents, users,
+           incidentStatusOptions, veracityOptions, escalatedOptions, Incident,
+           Socket, Queue, paginationOptions, Tags) {
     $scope.searchParams = $stateParams;
     $scope.incidents = incidents.results;
     $scope.statusOptions = incidentStatusOptions;
@@ -220,9 +223,7 @@ angular.module('Aggie')
       Socket.removeAllListeners('incidents');
     });
 
-    $scope.tagsToString = function(tags) {
-      return tags.join(', ');
-    };
+    $scope.tagsToString = Tags.tagsToString;
 
     init();
   }

--- a/public/angular/js/controllers/incidents/index.js
+++ b/public/angular/js/controllers/incidents/index.js
@@ -220,6 +220,10 @@ angular.module('Aggie')
       Socket.removeAllListeners('incidents');
     });
 
+    $scope.tagsToString = function(tags) {
+      return tags.join(', ');
+    };
+
     init();
   }
 ]);

--- a/public/angular/js/routes.js
+++ b/public/angular/js/routes.js
@@ -2,7 +2,7 @@ angular.module('Aggie')
 
 .config([
   '$stateProvider',
-  function($stateProvider, tz) {
+  function($stateProvider) {
     var lastAnalysis;
 
     $stateProvider.state('home', {
@@ -109,21 +109,13 @@ angular.module('Aggie')
       }
     });
 
-    var tokenize = function(tags) {
-      if (typeof tags === 'string') {
-        return tags.split(',').map(function(tag) {
-          return tag.trim();
-        });
-      }
-      return tags;
-    };
 
     $stateProvider.state('incidents', {
       url: '/incidents?page&title&locationName&assignedTo&status&veracity&tags&escalated',
       templateUrl: '/templates/incidents/index.html',
       controller: 'IncidentsIndexController',
       resolve: {
-        incidents: ['Incident', '$stateParams', function(Incident, params) {
+        incidents: ['Incident', '$stateParams', 'Tags', function(Incident, params, Tags) {
           var page = params.page || 1;
           return Incident.query({
             page: page - 1,
@@ -132,7 +124,7 @@ angular.module('Aggie')
             assignedTo: params.assignedTo,
             status: params.status,
             veracity: params.veracity,
-            tags: tokenize(params.tags),
+            tags: Tags.stringToTags(params.tags),
             escalated: params.escalated
           }).$promise;
         }],

--- a/public/angular/js/services/tags.js
+++ b/public/angular/js/services/tags.js
@@ -1,0 +1,18 @@
+'use strict';
+
+angular.module('Aggie')
+.factory('Tags', function() {
+  return {
+    tagsToString: function(tags) {
+      return tags.join(', ');
+    },
+    stringToTags: function(tags) {
+      if (typeof tags === 'string') {
+        return tags.split(',').map(function(tag) {
+          return tag.trim();
+        });
+      }
+      return tags;
+    }
+  };
+});

--- a/public/angular/templates/incidents/modal.html
+++ b/public/angular/templates/incidents/modal.html
@@ -82,6 +82,14 @@
               </div>
             </div>
           </div>
+
+          <div class="form-group">
+            <label for="tags" class="col-lg-2 control-label" translate>Tags</label>
+            <div class="col-lg-9">
+              <input id="tags" name="tags" type="text" class="form-control" ng-model="incident.tags" ng-focus>
+            </div>
+          </div>
+
           <div class="form-group" ng-hide="minimal">
             <label for="user" class="col-lg-2 control-label" translate>Assign To</label>
             <div class="col-lg-9">

--- a/public/angular/templates/incidents/table.html
+++ b/public/angular/templates/incidents/table.html
@@ -8,7 +8,8 @@
       <th ng-show="currentUser.can('view other users')" class="compact" translate>Assigned To</th>
       <th class="compact" translate>Status</th>
       <th class="compact" translate>Veracity</th>
-      <th class="compact translate">Escalated?</th>
+      <th class="compact" translate>Escalated?</th>
+      <th class="compact" translate>Tags</th>
       <th class="compact" translate>Last Updated</th>
       <th ng-hide="modal || !currentUser.can('edit data')" class="compact"></th>
     </tr>
@@ -40,6 +41,7 @@
         </div>
       </td>
       <td class="compact content">{{ {false: 'No', true: 'Yes'}[i.escalated] | translate }}</td>
+      <td class="compact content">{{ tagsToString(i.tags) }}</td>
       <td class="compact">
         <div class="interval">
           <span class="interval-amount">{{ i.updatedAt | interval }}</span>


### PR DESCRIPTION
The incident modal now has a field to add a list of tags to an incident (id is `tags`), and the table at `/incidents` has a column for an incident's tags. Also resolves 5328.
