### PR TITLE
Filter incident by tags

### DIFF
--- a/lib/api/v1/incident-controller.js
+++ b/lib/api/v1/incident-controller.js
@@ -2,7 +2,7 @@
 
 var express = require('express');
 var Incident = require('../../../models/incident');
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = function(app, user) {
   app = app || express();
@@ -14,6 +14,7 @@ module.exports = function(app, user) {
   // Create a new Incident
   app.post('/api/v1/incident', user.can('edit incidents'), function(req, res) {
     req.body.creator = req.user;
+    if (req.body.tags) req.body.tags = req.body.tags.split(',').map(_.trim);
     Incident.create(req.body, function(err, incident) {
       if (err) res.send(err.status, err.message);
       else res.send(200, incident);
@@ -53,7 +54,9 @@ module.exports = function(app, user) {
       if (err) return res.send(err.status, err.message);
       if (!incident) return res.send(404);
       // Update the actual values
-      incident = _.extend(incident, _.omit(req.body, 'creator'));
+      var update = _.omit(req.body, 'creator');
+      if (update.tags) update.tags = update.tags.split(',').map(_.trim);
+      incident = _.extend(incident, update);
 
       // Save incident
       incident.save(function(err, numberAffected) {
@@ -117,5 +120,7 @@ module.exports = function(app, user) {
 
 function parseQueryData(queryString) {
   if (!queryString) return {};
-  return _.pick(queryString, Incident.filterAttributes);
+  var query = _.pick(queryString, Incident.filterAttributes);
+  if (query.tags) query.tags = query.tags.split(',').map(_.trim);
+  return query;
 }

--- a/models/incident.js
+++ b/models/incident.js
@@ -145,7 +145,7 @@ Incident.queryIncidents = function(query, page, options, callback) {
 
   // Checking for multiple tags in incident
   if (query.tags) {
-    filter.tags = { $in: query.tags };
+    filter.tags = { $all: query.tags };
   } else delete filter.tags;
 
   // Re-set search timestamp

--- a/public/angular/js/controllers/incidents/form_modal.js
+++ b/public/angular/js/controllers/incidents/form_modal.js
@@ -107,9 +107,8 @@ angular.module('Aggie')
   'users',
   'incident',
   'reports',
-  'Tags',
   function($scope, $modalInstance, incidentStatusOptions, veracityOptions,
-           users, incident, reports, Tags) {
+           users, incident, reports) {
     $scope.incident = angular.copy(incident);
     $scope.users = users;
     $scope.veracity = veracityOptions;
@@ -128,7 +127,7 @@ angular.module('Aggie')
 
       // Only send assignedTo _id, not whole object.
       $scope.incident.assignedTo = ($scope.incident.assignedTo || { _id: null })['_id'];
-      $scope.incident.tags = Tags.stringToTags($scope.incident.tags);
+      $scope.incident.tags = $scope.incident.tags;
 
       $modalInstance.close($scope.incident);
     };

--- a/public/angular/js/routes.js
+++ b/public/angular/js/routes.js
@@ -115,7 +115,7 @@ angular.module('Aggie')
       templateUrl: '/templates/incidents/index.html',
       controller: 'IncidentsIndexController',
       resolve: {
-        incidents: ['Incident', '$stateParams', 'Tags', function(Incident, params, Tags) {
+        incidents: ['Incident', '$stateParams', function(Incident, params) {
           var page = params.page || 1;
           return Incident.query({
             page: page - 1,
@@ -124,7 +124,7 @@ angular.module('Aggie')
             assignedTo: params.assignedTo,
             status: params.status,
             veracity: params.veracity,
-            tags: Tags.stringToTags(params.tags),
+            tags: params.tags,
             escalated: params.escalated
           }).$promise;
         }],

--- a/public/angular/js/services/tags.js
+++ b/public/angular/js/services/tags.js
@@ -5,14 +5,6 @@ angular.module('Aggie')
   return {
     tagsToString: function(tags) {
       return tags.join(', ');
-    },
-    stringToTags: function(tags) {
-      if (typeof tags === 'string') {
-        return tags.split(',').map(function(tag) {
-          return tag.trim();
-        });
-      }
-      return tags;
     }
   };
 });

--- a/shared/incident.js
+++ b/shared/incident.js
@@ -8,7 +8,10 @@
     }
   };
 
-  Incident.filterAttributes = ['title', 'locationName', 'assignedTo', 'status', 'veracity', 'escalated'];
+  Incident.filterAttributes = [
+    'title', 'locationName', 'assignedTo', 'status', 'veracity',
+    'escalated', 'tags'
+  ];
   Incident.statusOptions = ['new', 'working', 'alert', 'closed'];
 
   // Export the Incident class for node.js

--- a/test/backend/models.query.incident-query.test.js
+++ b/test/backend/models.query.incident-query.test.js
@@ -74,7 +74,7 @@ describe('Incident query attributes', function() {
 
   it('should normalize query', function() {
     var normalized = query.normalize();
-    expect(normalized).to.have.keys(['title', 'locationName', 'assignedTo', 'veracity']);
+    expect(normalized).to.have.keys(['title', 'locationName', 'assignedTo', 'veracity', 'tags']);
     expect(normalized.title).to.equal('quick brown');
   });
 

--- a/test/backend/models.query.incident-query.test.js
+++ b/test/backend/models.query.incident-query.test.js
@@ -144,7 +144,7 @@ describe('Incident query attributes', function() {
 
   it('should query by single full tag', incidentTagTester(['foobar'], 2));
 
-  it('should query by multiple full tags', incidentTagTester(['wellohorld', 'foobar'], 3));
+  it('should query by multiple full tags', incidentTagTester(['wellohorld', 'foobar'], 1));
 
   after(utils.wipeModels([Incident]));
   after(utils.expectModelsEmpty);


### PR DESCRIPTION
Fixes some bugs from #209, #210, #211, #213 so that filtering incidents by tags works. This passes the tests in #214.