### PR TITLE
5422 smsgh case handling

### DIFF
--- a/lib/fetching/content-services/smsgh-content-service.js
+++ b/lib/fetching/content-services/smsgh-content-service.js
@@ -12,16 +12,12 @@ function SMSGhContentService(port) {
   this._connectedSources = {};
   var self = this;
 
-  var getKeyword = function(req) {
-    return 'sms_ghana:' + req.query.keyword;
-  };
-
   this._app.get('/smsghana', function(req, res) {
 
     var _params = req.query;
     res.send(200);
     var reportData = self._parse(_params);
-    self.emit(getKeyword(req), reportData);
+    self.emit(self._getKeyword(req.query.keyword), reportData);
 
   });
 
@@ -30,15 +26,18 @@ function SMSGhContentService(port) {
 
 util.inherits(SMSGhContentService, ContentService);
 
+SMSGhContentService.prototype._getKeyword = function(keyword) {
+  return 'sms_ghana:' + keyword.toLowerCase();
+};
+
 SMSGhContentService.prototype.subscribe = function(id, info) {
-  var keyword = info.keywords;
+  var keyword = this._getKeyword(info.keywords);
   this._connectedSources[id] = keyword;
-  if (this._isListening) {
-    return 'sms_ghana:' + keyword;
+  if (!this._isListening) {
+    this.server = this._app.listen(this.port);
+    this._isListening = true;
   }
-  this._isListening = true;
-  this.server = this._app.listen(this.port);
-  return 'sms_ghana:' + keyword;
+  return keyword;
 };
 
 SMSGhContentService.prototype.unsubscribe = function(id) {
@@ -66,8 +65,8 @@ SMSGhContentService.prototype._parse = function(query) {
   returnObject.fetchedAt = new Date();
   returnObject.url = ''; // since url is part of the schema
   returnObject.author = query.from;
-  returnObject.keyword = query.keyword.toLowerCase(); // This may need to change
-  returnObject.content = query.fulltext.toLowerCase(); // This may need to change
+  returnObject.keyword = query.keyword.toLowerCase();
+  returnObject.content = query.fulltext;
   return returnObject;
 };
 

--- a/test/backend/lib.fetching.content-services.smsgh-content-service.test.js
+++ b/test/backend/lib.fetching.content-services.smsgh-content-service.test.js
@@ -38,7 +38,7 @@ describe('SMSGhana content service', function() {
 
     beforeEach(function() {
       service = SMSGhContentService;
-      dummyEventName = service.subscribe('foo123', { keywords: 'dummy' });
+      dummyEventName = service.subscribe('foo123', { keywords: 'DuMmY' });
     });
 
     afterEach(function() {
@@ -146,7 +146,6 @@ describe('SMSGhana content service', function() {
             expect(reportData.authoredAt).to.eql(new Date('2016-09-01'));
             expect(reportData.content).to.equal('lorem ipsum dolor');
             expect(reportData.author).to.equal('9845098450');
-
             callback();
           });
         },
@@ -183,6 +182,46 @@ describe('SMSGhana content service', function() {
       service.unsubscribe('id_dodo123');
     });
 
+    it('should be case-insensitive', function(done) {
+      var expectReport = function(callback, reportData) {
+        expect(reportData.authoredAt).to.eql(new Date('2016-09-01'));
+        expect(reportData.content).to.equal('lorem ipsum dolor');
+        expect(reportData.author).to.equal('9845098450');
+        expect(reportData.keyword).to.equal('dummy');
+        callback();
+      };
+      async.parallel([
+        function(callback) {
+          service.once(dummyEventName, expectReport.bind({}, callback));
+        },
+        function(callback) {
+          service.once(dummyEventName, expectReport.bind({}, callback));
+        }
+      ], done);
+
+      reqParams.keyword = 'Dummy';
+      request('http://localhost:1111')
+        .get('/smsghana')
+        .query(reqParams)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+        });
+
+      reqParams.keyword = 'DUMMY';
+      request('http://localhost:1111')
+        .get('/smsghana')
+        .query(reqParams)
+        .expect(200)
+        .end(function(err, res) {
+          if (err) {
+            return done(err);
+          }
+        });
+
+    });
 
   });
 


### PR DESCRIPTION
Emitting SMS reports with keyword lowercased
Both the source-identifier and request's keyword are different cases
`getKeyword` function ensures uniformity between request's keyword and source's keyword

Fixed merge conflicts, replacing #227 