### PR TITLE
5470 Report, incident tag filters ignore case

### DIFF
--- a/models/incident.js
+++ b/models/incident.js
@@ -13,6 +13,7 @@ var autoIncrement = require('mongoose-auto-increment');
 var listenTo = require('mongoose-listento');
 var Report = require('./report');
 var logger = require('../lib/logger');
+var toRegexp = require('./to-regexp');
 
 require('../lib/error');
 
@@ -145,7 +146,7 @@ Incident.queryIncidents = function(query, page, options, callback) {
 
   // Checking for multiple tags in incident
   if (query.tags) {
-    filter.tags = { $all: query.tags };
+    filter.tags = { $all: toRegexp.allCaseInsensitive(query.tags) };
   } else delete filter.tags;
 
   // Re-set search timestamp

--- a/models/query/report-query.js
+++ b/models/query/report-query.js
@@ -5,6 +5,7 @@ var Report = require('../report');
 var Query = require('../query');
 var util = require('util');
 var _ = require('lodash');
+var toRegexp = require('../to-regexp');
 
 function ReportQuery(options) {
   options = options || {};
@@ -67,13 +68,10 @@ ReportQuery.prototype.toMongooseFilter = function() {
   // Determine author filter
   if (this.author) {
     filter.author = {};
-    filter.author.$in = this.author.trim().split(/\s*,\s*/).sort().map(function(author) {
-      // Use case-insensitive matching with anchors so mongo index is still used.
-      return new RegExp('^' + author + '$', 'i');
-    });
+    filter.author.$in = toRegexp.alli(this.author.trim().split(/\s*,\s*/).sort());
   }
   if (this.tags) {
-    filter.tags = { $all: this.tags };
+    filter.tags = { $all: toRegexp.allCaseInsensitive(this.tags) };
   } else delete filter.tags;
 
   // Search by keyword

--- a/models/to-regexp.js
+++ b/models/to-regexp.js
@@ -1,0 +1,22 @@
+/*
+ * Very basic shared function between some models
+ */
+'use strict';
+
+function toRegexp(caseInsensitive, str) {
+  var s = '^' + str + '$';
+  if (caseInsensitive) {
+    return new RegExp(s, 'i');
+  }
+  return new RegExp(s);
+}
+module.exports = toRegexp;
+
+var i = toRegexp.bind({}, true);
+module.exports.i = i;
+
+function alli(strs) {
+  return strs.map(i);
+}
+module.exports.alli = alli;
+module.exports.allCaseInsensitive = alli;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "aggie",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "dependencies": {
     "Base64": {
       "version": "0.2.1",


### PR DESCRIPTION
For mongo's `$all` queries, we pass regular expressions to do a
case insensitive match on tags.