### PR TITLE
Don't show new reports notification in batch mode

### DIFF
--- a/public/angular/templates/reports/batch.html
+++ b/public/angular/templates/reports/batch.html
@@ -1,5 +1,3 @@
-<alert type="info" ng-hide="newReports.isEmpty()"><a href class="alert-link" ng-click="displayNewReports()">{{ newReports.total }} {{ 'new reports available.' | translate }}</a></alert>
-
 <div class="batch-mode">
   <div class="pull-left">
     <p class="title" translate>Batch Mode</p>


### PR DESCRIPTION
As Tom said in #129, "The 'xx new reports have arrived'
bar should not show up when in batch mode."