### PR TITLE
Removed unique property for indexing user logs

### DIFF
--- a/lib/userLogger.js
+++ b/lib/userLogger.js
@@ -13,7 +13,7 @@ var logSchema = new mongoose.Schema({
   actionRef: mongoose.Schema.Types.Mixed
 });
 
-logSchema.index({ timestamp: 1, userID: 1 }, { unique: true });
+logSchema.index({ timestamp: 1, userID: 1 });
 var UserLog = mongoose.model('UserLog', logSchema);
 
 UserLog.writeToCollection = function(logItem, callback) {


### PR DESCRIPTION
There are some user actions that trigger more than one user log action at the same time. For example, adding a report to an incident (involving creating an incident) first creates the incident, and immediately adds the report to an incident. With the unique property, there were errors as these actions used to occur within the same millisecond.
