### PR TITLE
Adding additional fields to make userlogs more useful

### DIFF
--- a/lib/api/v1/report-controller.js
+++ b/lib/api/v1/report-controller.js
@@ -43,7 +43,10 @@ module.exports = function(app, user) {
   app.get('/api/v1/report/batch', user.can('view data'), function(req, res) {
     batch.load(req.session.user._id, function(err, reports) {
       if (err) res.send(err.status, err.message);
-      else res.send(200, { results: reports, total: reports.length });
+      else {
+        writelog.writeBatch(req, 'loadBatch', reports);
+        res.send(200, { results: reports, total: reports.length });
+      }
     });
   });
 
@@ -52,7 +55,10 @@ module.exports = function(app, user) {
     var query = new ReportQuery(req.body);
     batch.checkout(req.session.user._id, query, function(err, reports) {
       if (err) res.send(err.status, err.message);
-      else res.send(200, { results: reports, total: reports.length });
+      else {
+        writelog.writeBatch(req, 'getNewBatch', reports);
+        res.send(200, { results: reports, total: reports.length });
+      }
     });
   });
 
@@ -60,7 +66,10 @@ module.exports = function(app, user) {
   app.put('/api/v1/report/batch', user.can('edit data'), function(req, res) {
     batch.cancel(req.session.user._id, function(err) {
       if (err) res.send(err.status, err.message);
-      else res.send(200);
+      else {
+        writelog.writeBatch(req, 'cancelBatch');
+        res.send(200);
+      }
     });
   });
 

--- a/lib/api/v1/report-controller.js
+++ b/lib/api/v1/report-controller.js
@@ -25,7 +25,10 @@ module.exports = function(app, user) {
       // Query for reports using fti
       Report.queryReports(query, page, function(err, reports) {
         if (err) res.send(err.status, err.message);
-        else res.send(200, reports);
+        else {
+          writelog.writeReport(req, reports, 'filter', query);
+          res.send(200, reports);
+        }
       });
     } else {
       // Return all reports using pagination

--- a/lib/api/v1/trend-controller.js
+++ b/lib/api/v1/trend-controller.js
@@ -5,6 +5,7 @@ var Trend = require('../../../models/trend');
 var Query = require('../../../models/query');
 var ReportQuery = require('../../../models/query/report-query');
 var _ = require('underscore');
+var writelog = require('../../writeLog');
 
 module.exports = function(app, user) {
   app = app || express();
@@ -31,8 +32,7 @@ module.exports = function(app, user) {
           }
         };
         app.on('trend:backfill', trendBackFillCallback);
-      }
-      else {
+      } else {
         return res.send(200, trend.toJSON());
       }
     });
@@ -43,7 +43,10 @@ module.exports = function(app, user) {
     var page = req.query.page || 1;
     Trend.findPaginatedCounts({}, page, function(err, trends) {
       if (err) res.send(err.status, err.message);
-      else res.send(200, trends);
+      else {
+        writelog.writeTrend(req, 'viewTrends');
+        res.send(200, trends);
+      }
     });
   });
 

--- a/lib/writeLog.js
+++ b/lib/writeLog.js
@@ -20,6 +20,18 @@ writer.writeIncident = function(req, incident, action) {
       referer: req.headers ? req.headers.referer : ''
     }
   };
+  if (action === 'editIncident' || action === 'createIncident') {
+    logDetails.actionRef.incidentInformation = {
+      location: incident.locationName,
+      notes: incident.notes,
+      assignedTo: incident.assignedTo,
+      closed: incident.closed,
+      escalated: incident.escalated,
+      veracity: incident.veracity,
+      status: incident.status,
+      tags: incident.tags
+    };
+  }
   userLogger.writeToCollection(logDetails, function(err) {
     if (err) logger.error(err);
   });
@@ -34,7 +46,8 @@ writer.writeSource = function(req, source, action) {
     actionRef: {
       sourceNickname: source.nickname,
       sourceID: source._id,
-      sourceURI: source.keywords ? source.keywords : source.url
+      sourceURI: source.keywords ? source.keywords : source.url,
+      sourceMedia: source.media
     }
   };
   if (action === 'enable/disable/editSource') {
@@ -58,6 +71,7 @@ writer.writeReport = function(req, report, action) {
     logDetails.actionRef = {
       reportContent: report.content,
       reporttID: report._id,
+      reportMedia: report._media,
       referer: req.headers ? req.headers.referer : ''
     };
   } else logDetails.actionRef = {};

--- a/lib/writeLog.js
+++ b/lib/writeLog.js
@@ -119,4 +119,17 @@ writer.writeBatch = function(req, action, reports) {
   });
 };
 
+writer.writeTrend = function(req, action) {
+  if (!logFlag) return;
+  var logDetails = {
+    userID: req.user._id,
+    username: req.user.username,
+    action: action,
+    actionRef: {}
+  };
+  userLogger.writeToCollection(logDetails, function(err) {
+    if (err) logger.error(err);
+  });
+};
+
 module.exports = writer;

--- a/lib/writeLog.js
+++ b/lib/writeLog.js
@@ -60,14 +60,14 @@ writer.writeSource = function(req, source, action) {
   });
 };
 
-writer.writeReport = function(req, report, action) {
+writer.writeReport = function(req, report, action, query) {
   if (!logFlag) return;
   var logDetails = {
     userID: req.user._id,
     username: req.user.username,
     action: action
   };
-  if (action !== 'deleteAllReports') {
+  if (action !== 'deleteAllReports' || action !== 'filter') {
     logDetails.actionRef = {
       reportContent: report.content,
       reporttID: report._id,
@@ -84,6 +84,9 @@ writer.writeReport = function(req, report, action) {
   }
   if (action === 'addToIncident') {
     logDetails.actionRef.incidentID = report._incident;
+  }
+  if (query) {
+    logDetails.actionRef = query;
   }
   userLogger.writeToCollection(logDetails, function(err) {
     if (err) logger.error(err);

--- a/lib/writeLog.js
+++ b/lib/writeLog.js
@@ -93,4 +93,30 @@ writer.writeReport = function(req, report, action, query) {
   });
 };
 
+writer.writeBatch = function(req, action, reports) {
+  if (!logFlag) return;
+  var logDetails = {
+    userID: req.user._id,
+    username: req.user.username,
+    action: action,
+    actionRef: {}
+  };
+  if (reports) {
+    var reportContents = [];
+    for (var report in reports) {
+      if (!reports.hasOwnProperty(report)) {
+        reportContents.push({
+          id: reports[report]._id,
+          media: reports[report]._media,
+          nickname: reports[report]._sourceNicknames
+        });
+      }
+    }
+    logDetails.actionRef.reports = reportContents;
+  }
+  userLogger.writeToCollection(logDetails, function(err) {
+    if (err) logger.error(err);
+  });
+};
+
 module.exports = writer;

--- a/lib/writeLog.js
+++ b/lib/writeLog.js
@@ -67,7 +67,7 @@ writer.writeReport = function(req, report, action, query) {
     username: req.user.username,
     action: action
   };
-  if (action !== 'deleteAllReports' || action !== 'filter') {
+  if (action !== 'deleteAllReports' && action !== 'filter') {
     logDetails.actionRef = {
       reportContent: report.content,
       reporttID: report._id,
@@ -103,15 +103,13 @@ writer.writeBatch = function(req, action, reports) {
   };
   if (reports) {
     var reportContents = [];
-    for (var report in reports) {
-      if (!reports.hasOwnProperty(report)) {
-        reportContents.push({
-          id: reports[report]._id,
-          media: reports[report]._media,
-          nickname: reports[report]._sourceNicknames
-        });
-      }
-    }
+    reports.forEach(function(report) {
+      reportContents.push({
+        id: report._id,
+        media: report._media,
+        nickname: report._sourceNicknames
+      });
+    });
     logDetails.actionRef.reports = reportContents;
   }
   userLogger.writeToCollection(logDetails, function(err) {


### PR DESCRIPTION
- Media of source/report touched added to user logs
- Storing more information when an incident is created/edited
- The filter in place for a user
- Grab batch

This PR can be kept open until the last moment, and all addition fields can be added to this branch, and later merged.