### PR TITLE
Enter no longer cancels the password change

### DIFF
--- a/public/angular/templates/choose_password.html
+++ b/public/angular/templates/choose_password.html
@@ -17,7 +17,7 @@
       </div>
       <div class="form-group">
         <div class="col-lg-10 col-lg-offset-2">
-          <button ng-click="cancel()" class="btn btn-default" translate>Cancel</button>
+          <button type="button" ng-click="cancel()" class="btn btn-default" translate>Cancel</button>
           <button type="submit" class="btn btn-primary" translate>Submit</button>
         </div>
       </div>


### PR DESCRIPTION
Turns out button elements without a `type="button"` are `type="submit"` by default!
Fixed that.