### PR TITLE
4459 Recreate the socket after logging in

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(karma) {
       'public/angular/js/app.js',
       'public/angular/templates/**/*.html',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/socket.io-client/dist/socket.io.js',
       'test/frontend/**/*.test.js'
     ],
 

--- a/public/angular/js/controllers/login.js
+++ b/public/angular/js/controllers/login.js
@@ -6,7 +6,8 @@ angular.module('Aggie')
     'AuthService',
     '$location',
     'FlashService',
-    function($scope, $state, $rootScope, AuthService, $location, flash) {
+    'Socket',
+    function($scope, $state, $rootScope, AuthService, $location, flash, Socket) {
       $scope.login = function(form) {
         AuthService.login({
           username: $scope.user.username,
@@ -14,6 +15,9 @@ angular.module('Aggie')
         },
           function(err) {
             if (!err) {
+              // Before login, socket should have failed to be created
+              // completely
+              Socket.recreateConnection();
               $state.go('reports');
             } else {
               flash.setAlertNow(err.data);

--- a/public/angular/js/services/socket.js
+++ b/public/angular/js/services/socket.js
@@ -33,6 +33,10 @@ angular.module('Aggie')
     },
 
     off: socket.removeListener.bind(socket),
-    removeAllListeners: socket.removeAllListeners.bind(socket)
+    removeAllListeners: socket.removeAllListeners.bind(socket),
+
+    recreateConnection: function() {
+      socket = io.connect('/', { 'force new connection': true });
+    }
   };
 });


### PR DESCRIPTION
The stats bar wasn't getting populated upon logging in because it was
trying to use the socket that was created when the page was loaded, at
which point the user wasn't authenticated.