### PR TITLE
Create incident uses 'edit data' permission

### DIFF
--- a/lib/api/v1/incident-controller.js
+++ b/lib/api/v1/incident-controller.js
@@ -15,7 +15,7 @@ module.exports = function(app, user) {
   app.use(express.json());
 
   // Create a new Incident
-  app.post('/api/v1/incident', user.can('edit incidents'), function(req, res) {
+  app.post('/api/v1/incident', user.can('edit data'), function(req, res) {
     req.body.creator = req.user;
     Incident.create(req.body, function(err, incident) {
       if (err) {


### PR DESCRIPTION
Creating an incident had been using the 'edit incidents' permission
which is not defined in `shared/user.js`.