### PR TITLE
Monitors can create/edit/delete trends

### DIFF
--- a/shared/user.js
+++ b/shared/user.js
@@ -11,7 +11,7 @@
   User.PASSWORD_MIN_LENGTH = 8;
 
   User.permissions = {
-    'manage trends': ['monitor', 'admin'],
+    'manage trends': ['admin'],
     'view data': ['viewer', 'monitor', 'admin'],
     'edit data': ['monitor', 'admin'],
     'change settings': ['admin'],

--- a/shared/user.js
+++ b/shared/user.js
@@ -11,6 +11,7 @@
   User.PASSWORD_MIN_LENGTH = 8;
 
   User.permissions = {
+    'manage trends': ['monitor', 'admin'],
     'view data': ['viewer', 'monitor', 'admin'],
     'edit data': ['monitor', 'admin'],
     'change settings': ['admin'],


### PR DESCRIPTION
There was no permissions allotted for 'manage trends', and therefore, monitors could not create trends. This has been fixed.