### PR TITLE
5539 Convert tags to array for grab batch with tags

### DIFF
--- a/public/angular/js/controllers/reports/index.js
+++ b/public/angular/js/controllers/reports/index.js
@@ -312,6 +312,7 @@ angular.module('Aggie')
     };
 
     $scope.grabBatch = function() {
+      $scope.searchParams.tags = Tags.stringToTags($scope.searchParams.tags);
       Batch.checkout($scope.searchParams, function(resource) {
         // no more results found
         if (!resource.results || !resource.results.length) {


### PR DESCRIPTION
Filtering reports uses the query string, and filtering incidents uses
the request body. Grabbing a batch uses the request body, so we pass an
array. If only this were standardized!