### PR TITLE
Added comment/post tag to Facebook reports

### DIFF
--- a/lib/fetching/bot.js
+++ b/lib/fetching/bot.js
@@ -102,6 +102,9 @@ Bot.prototype._reportListener = function(reportData) {
       if (reportData._media === 'twitter') {
         reportData.metadata.retweet ? reportData.tags.push('RT') : reportData.tags.push('NO_RT');
       }
+      if (reportData._media === 'facebook') {
+        reportData.metadata.isComment ? reportData.tags.push('FBComment') : reportData.tags.push('FBPost');
+      }
     }
 
     var drops = this.queue.drops;

--- a/lib/fetching/content-services/facebook-content-service.js
+++ b/lib/fetching/content-services/facebook-content-service.js
@@ -150,7 +150,7 @@ FacebookContentService.prototype._handleResults = function(data) {
     reportData.push(self._parse(post));
     if (post.comments && post.comments.data && post.comments.data.length > 0) {
       post.comments.data.forEach(function(comment) {
-        comment.permalink_url = post.permalink_url;
+        comment.permalink_url = 'https://www.facebook.com/' + comment.id;
         comment.isComment = true;
         reportData.push(self._parse(comment));
       });

--- a/lib/fetching/content-services/facebook-content-service.js
+++ b/lib/fetching/content-services/facebook-content-service.js
@@ -146,10 +146,12 @@ FacebookContentService.prototype._handleResults = function(data) {
 
   data.forEach(function(post) {
       // Handle each post and any comments already attached to it
+    post.isComment = false;
     reportData.push(self._parse(post));
     if (post.comments && post.comments.data && post.comments.data.length > 0) {
       post.comments.data.forEach(function(comment) {
         comment.permalink_url = post.permalink_url;
+        comment.isComment = true;
         reportData.push(self._parse(comment));
       });
     }
@@ -170,7 +172,8 @@ FacebookContentService.prototype._parse = function(data) {
     likeCount: data.likes ? data.likes.summary.total_count : 0,
     reactionCount: data.reactions ? data.reactions.summary.total_count : 0,
     place: data.place ? data.place : '',
-    link: data.link ? data.link : ''
+    link: data.link ? data.link : '',
+    isComment: Boolean(data.isComment)
   };
   return {
     authoredAt: new Date(data.created_time),


### PR DESCRIPTION
Since Twitter has an RT and NO_RT tag added, I feel it's required for Facebook as well, given that sometimes comments might not be as useful as posts to get relevant information.
So, I've followed Andrés' model on adding the twitter RT|NO_RT tag, and done the same for Facebook.