### PR TITLE
Apply tag filter with Grab Another

### DIFF
--- a/public/angular/js/routes.js
+++ b/public/angular/js/routes.js
@@ -71,7 +71,7 @@ angular.module('Aggie')
     });
 
     $stateProvider.state('batch', {
-      url: '/reports/batch?keywords&before&after&sourceId&status&media&incidentId&author',
+      url: '/reports/batch?keywords&before&after&sourceId&status&media&incidentId&author&tags',
       templateUrl: '/templates/reports/batch.html',
       controller: 'ReportsIndexController',
       resolve: {


### PR DESCRIPTION
Grab batch will apply a filter you have set up, but when clicking Mark
All Read & Grab Another, Aggie was forgetting about the tags part of the
filter.