### PR TITLE
Get multiple sources correctly

### DIFF
--- a/lib/fetching/content-services/twitter-content-service.js
+++ b/lib/fetching/content-services/twitter-content-service.js
@@ -94,8 +94,8 @@ TwitterContentService.prototype._makeReport = function(tweet) {
     var b = tweetMatches(tweet, compiled);
     return b;
   });
-  tweet._sources = _.mapValues(matchingBots, 'sourceId');
-  tweet._sourceNicknames = _.mapValues(matchingBots, 'sourceName');
+  tweet._sources = _.values(_.mapValues(matchingBots, 'sourceId'));
+  tweet._sourceNicknames = _.values(_.mapValues(matchingBots, 'sourceName'));
   var botIds = _.keys(matchingBots);
   if (botIds.length === 0) {
     throw new Error('tweet-matches failed with keywords ' + this._keywords);
@@ -130,7 +130,9 @@ TwitterContentService.prototype._parse = function(data) {
     content: data.text,
     author: author,
     metadata: metadata,
-    url: author ? 'https://twitter.com/' + author + '/status/' + data.id_str : null
+    url: author ? 'https://twitter.com/' + author + '/status/' + data.id_str : null,
+    _sources: data._sources,
+    _sourceNicknames: data._sourceNicknames
   };
 };
 

--- a/public/angular/sass/components/tables.scss
+++ b/public/angular/sass/components/tables.scss
@@ -329,3 +329,8 @@ td.content {
   box-sizing: border-box;
 }
 
+td {
+  span.source {
+    display: block;
+  }
+}

--- a/public/angular/templates/reports/table.html
+++ b/public/angular/templates/reports/table.html
@@ -29,7 +29,7 @@
         <div class="icon-left"></div>
       </td>
       <td class="compact source" ng-class="{ strong: !isRead(r) }">
-        <span ng-repeat="s in r._sources">
+        <span ng-repeat="s in r._sources" class="source">
           {{ sourcesById[s].nickname || '[Deleted]' }}
         </span>
       </td>


### PR DESCRIPTION
Tweets can now actually have multiple sources. `_sources`
and `_sourceNicknames` were supposed to be arrays, but
`_.mapValues` makes an object.