### PR TITLE
5584: Locking a batch is now atomic using read/write lock

### DIFF
--- a/lib/fetching/content-services/replay-content-service.js
+++ b/lib/fetching/content-services/replay-content-service.js
@@ -4,7 +4,7 @@
 var ContentService = require('../content-service');
 var util = require('util');
 
-var JSONStream = require('jsonstream');
+var JSONStream = require('JSONStream');
 var join = require('path').join;
 var fs = require ('fs');
 var config = require('../../../config/secrets');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,271 +1,266 @@
 {
   "name": "aggie",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "dependencies": {
     "Base64": {
       "version": "0.2.1",
-      "from": "Base64@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
     },
     "JSONStream": {
       "version": "0.7.4",
-      "from": "JSONStream@>=0.7.1 <0.8.0",
+      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz"
     },
     "accepts": {
       "version": "1.1.4",
-      "from": "accepts@1.1.4",
+      "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
       "dependencies": {
-        "mime-db": {
-          "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-        },
         "mime-types": {
           "version": "2.0.14",
-          "from": "mime-types@>=2.0.4 <2.1.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
         },
         "negotiator": {
           "version": "0.4.9",
-          "from": "negotiator@0.4.9",
+          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         }
       }
     },
     "accessibility-developer-tools": {
       "version": "2.6.0",
-      "from": "accessibility-developer-tools@>=2.6.0 <2.7.0",
+      "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
     },
     "acorn": {
       "version": "1.2.2",
-      "from": "acorn@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
     },
     "active-x-obfuscator": {
       "version": "0.0.1",
-      "from": "active-x-obfuscator@0.0.1",
+      "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz"
     },
     "addressparser": {
       "version": "0.1.3",
-      "from": "addressparser@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.1.3.tgz"
     },
     "adm-zip": {
       "version": "0.4.4",
-      "from": "adm-zip@0.4.4",
+      "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
     },
     "after": {
       "version": "0.8.1",
-      "from": "after@0.8.1",
+      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
     },
     "agent-base": {
       "version": "2.0.1",
-      "from": "agent-base@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
       "dependencies": {
         "semver": {
           "version": "5.0.3",
-          "from": "semver@>=5.0.1 <5.1.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
         }
       }
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "amazon-ses": {
       "version": "0.0.3",
-      "from": "amazon-ses@0.0.3",
+      "from": "https://registry.npmjs.org/amazon-ses/-/amazon-ses-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/amazon-ses/-/amazon-ses-0.0.3.tgz",
       "dependencies": {
         "request": {
           "version": "2.1.1",
-          "from": "request@2.1.1",
+          "from": "https://registry.npmjs.org/request/-/request-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.1.1.tgz"
         },
         "underscore": {
           "version": "1.2.1",
-          "from": "underscore@1.2.1",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz"
         },
         "xml2js": {
           "version": "0.1.11",
-          "from": "xml2js@0.1.11",
+          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.11.tgz",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.11.tgz"
         }
       }
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
+      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "angular": {
       "version": "1.5.8",
-      "from": "angular@>=1.2.26 <1.7.0",
+      "from": "https://registry.npmjs.org/angular/-/angular-1.5.8.tgz",
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.8.tgz"
     },
     "angular-cookies": {
       "version": "1.2.32",
-      "from": "angular-cookies@1.2.32",
+      "from": "https://registry.npmjs.org/angular-cookies/-/angular-cookies-1.2.32.tgz",
       "resolved": "https://registry.npmjs.org/angular-cookies/-/angular-cookies-1.2.32.tgz"
-    },
-    "angular-mocks": {
-      "version": "1.2.18",
-      "from": "angular-mocks@1.2.18",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.2.18.tgz"
     },
     "angular-translate": {
       "version": "2.13.0",
-      "from": "angular-translate@2.13.0",
+      "from": "https://registry.npmjs.org/angular-translate/-/angular-translate-2.13.0.tgz",
       "resolved": "https://registry.npmjs.org/angular-translate/-/angular-translate-2.13.0.tgz"
     },
     "angular-translate-handler-log": {
       "version": "2.13.0",
-      "from": "angular-translate-handler-log@2.13.0",
+      "from": "https://registry.npmjs.org/angular-translate-handler-log/-/angular-translate-handler-log-2.13.0.tgz",
       "resolved": "https://registry.npmjs.org/angular-translate-handler-log/-/angular-translate-handler-log-2.13.0.tgz"
     },
     "angular-translate-loader-static-files": {
       "version": "2.13.0",
-      "from": "angular-translate-loader-static-files@2.13.0",
+      "from": "https://registry.npmjs.org/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.13.0.tgz",
       "resolved": "https://registry.npmjs.org/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.13.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "anymatch": {
       "version": "1.3.0",
-      "from": "anymatch@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "archy": {
       "version": "1.0.0",
-      "from": "archy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
     "array-filter": {
       "version": "0.0.1",
-      "from": "array-filter@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-indexofobject": {
       "version": "0.0.1",
-      "from": "array-indexofobject@0.0.1",
+      "from": "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz"
     },
     "array-map": {
       "version": "0.0.0",
-      "from": "array-map@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
     },
     "array-reduce": {
       "version": "0.0.0",
-      "from": "array-reduce@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
     },
     "array-slice": {
       "version": "0.2.3",
-      "from": "array-slice@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
-      "from": "arraybuffer.slice@0.0.6",
+      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
       "version": "1.0.0",
-      "from": "asap@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
     },
     "asn1": {
       "version": "0.1.11",
-      "from": "asn1@0.1.11",
+      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
     },
     "asn1.js": {
       "version": "4.8.1",
-      "from": "asn1.js@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz"
     },
     "assert": {
       "version": "1.1.2",
-      "from": "assert@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
     },
     "assert-plus": {
       "version": "0.1.5",
-      "from": "assert-plus@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "astw": {
       "version": "2.0.0",
-      "from": "astw@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz"
     },
     "async": {
       "version": "0.9.2",
-      "from": "async@>=0.9.0 <0.10.0",
+      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
     },
     "async-each": {
       "version": "1.0.1",
-      "from": "async-each@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
     },
     "asynckit": {
@@ -275,178 +270,178 @@
     },
     "aws-sdk": {
       "version": "2.6.14",
-      "from": "aws-sdk@>=2.6.12 <3.0.0",
+      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.14.tgz",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.14.tgz",
       "dependencies": {
-        "base64-js": {
-          "version": "1.2.0",
-          "from": "base64-js@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
-        },
         "buffer": {
           "version": "4.9.1",
-          "from": "buffer@4.9.1",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "sax": {
           "version": "1.1.5",
-          "from": "sax@1.1.5",
+          "from": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "aws-sign2": {
       "version": "0.5.0",
-      "from": "aws-sign2@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
     },
     "aws4": {
       "version": "1.4.1",
-      "from": "aws4@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
     },
     "backo2": {
       "version": "1.0.2",
-      "from": "backo2@1.0.2",
+      "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base64-arraybuffer": {
       "version": "0.1.2",
-      "from": "base64-arraybuffer@0.1.2",
+      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
     },
     "base64-js": {
       "version": "0.0.8",
-      "from": "base64-js@>=0.0.4 <0.1.0",
+      "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
     },
     "base64id": {
       "version": "0.1.0",
-      "from": "base64id@0.1.0",
+      "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
     },
     "batch": {
       "version": "0.5.0",
-      "from": "batch@0.5.0",
+      "from": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
     },
     "bcrypt-nodejs": {
       "version": "0.0.3",
-      "from": "bcrypt-nodejs@0.0.3",
+      "from": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.0",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "dependencies": {
         "tweetnacl": {
           "version": "0.14.3",
-          "from": "tweetnacl@>=0.14.3 <0.15.0",
+          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
         }
       }
     },
     "beeper": {
       "version": "1.1.0",
-      "from": "beeper@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "benchmark": {
       "version": "1.0.0",
-      "from": "benchmark@1.0.0",
+      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
-      "from": "better-assert@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "binary-extensions": {
       "version": "1.7.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz"
     },
     "bindings": {
       "version": "1.2.1",
-      "from": "bindings@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "blob": {
       "version": "0.0.4",
-      "from": "blob@0.0.4",
+      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
       "version": "2.10.2",
-      "from": "bluebird@2.10.2",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "bn.js": {
       "version": "4.11.6",
-      "from": "bn.js@>=4.1.1 <5.0.0",
+      "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
     },
     "body-parser": {
       "version": "1.14.2",
-      "from": "body-parser@>=1.14.0 <1.15.0",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
-          "from": "bytes@2.2.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "qs": {
           "version": "5.2.0",
-          "from": "qs@5.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "raw-body": {
           "version": "2.1.7",
-          "from": "raw-body@>=2.1.5 <2.2.0",
+          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
-              "from": "bytes@2.4.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             }
           }
@@ -455,37 +450,37 @@
     },
     "boom": {
       "version": "0.4.2",
-      "from": "boom@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
     },
     "brace-expansion": {
       "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
+      "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "brorand": {
       "version": "1.0.6",
-      "from": "brorand@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
     },
     "browser-pack": {
       "version": "2.0.1",
-      "from": "browser-pack@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.6.4",
-          "from": "JSONStream@>=0.6.4 <0.7.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "dependencies": {
             "through": {
               "version": "2.2.7",
-              "from": "through@>=2.2.7 <2.3.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
             }
           }
@@ -494,104 +489,104 @@
     },
     "browser-resolve": {
       "version": "1.2.4",
-      "from": "browser-resolve@>=1.2.1 <1.3.0",
+      "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz"
     },
     "browserify": {
       "version": "3.46.1",
-      "from": "browserify@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-3.46.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-3.46.1.tgz"
     },
     "browserify-aes": {
       "version": "1.0.6",
-      "from": "browserify-aes@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
     },
     "browserify-cipher": {
       "version": "1.0.0",
-      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
     },
     "browserify-des": {
       "version": "1.0.0",
-      "from": "browserify-des@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
     },
     "browserify-shim": {
       "version": "2.0.10",
-      "from": "browserify-shim@>=2.0.10 <2.1.0",
+      "from": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-2.0.10.tgz",
       "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-2.0.10.tgz"
     },
     "browserify-sign": {
       "version": "4.0.0",
-      "from": "browserify-sign@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "from": "browserify-zlib@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "bson": {
       "version": "0.2.22",
-      "from": "bson@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
       "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz"
     },
     "buffer": {
       "version": "2.1.13",
-      "from": "buffer@>=2.1.4 <2.2.0",
+      "from": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz"
     },
     "buffer-crc32": {
       "version": "0.2.1",
-      "from": "buffer-crc32@0.2.1",
+      "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "from": "buffer-xor@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
     },
     "bufferutil": {
       "version": "1.2.1",
-      "from": "bufferutil@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
       "dependencies": {
         "nan": {
           "version": "2.4.0",
-          "from": "nan@>=2.0.5 <3.0.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         }
       }
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "builtins": {
       "version": "0.0.7",
-      "from": "builtins@>=0.0.3 <0.1.0",
+      "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
     },
     "bytes": {
       "version": "0.2.1",
-      "from": "bytes@0.2.1",
+      "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
     },
     "callsite": {
       "version": "1.0.0",
-      "from": "callsite@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
     },
     "camelcase": {
@@ -601,433 +596,1007 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "caseless": {
       "version": "0.11.0",
-      "from": "caseless@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
-    },
-    "chai": {
-      "version": "3.5.0",
-      "from": "chai@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "from": "chai-as-promised@>=5.1.0 <6.0.0",
+      "from": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
     "chai-dom": {
       "version": "1.4.2",
-      "from": "chai-dom@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.4.2.tgz"
     },
     "chai-jquery": {
       "version": "2.0.0",
-      "from": "chai-jquery@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz"
     },
     "chai-things": {
       "version": "0.2.0",
-      "from": "chai-things@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "chance": {
       "version": "0.7.7",
-      "from": "chance@>=0.7.1 <0.8.0",
+      "from": "https://registry.npmjs.org/chance/-/chance-0.7.7.tgz",
       "resolved": "https://registry.npmjs.org/chance/-/chance-0.7.7.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "character-parser": {
       "version": "1.0.2",
-      "from": "character-parser@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
     },
     "chokidar": {
       "version": "1.6.1",
-      "from": "chokidar@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "dependencies": {
+        "fsevents": {
+          "version": "1.1.2",
+          "from": "fsevents@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "2.7.0",
+              "from": "nan@>=2.3.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
+            },
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "from": "node-pre-gyp@^0.6.36",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
+            },
+            "abbrev": {
+              "version": "1.1.0",
+              "from": "abbrev@1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "ansi-regex@2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "from": "ajv@4.11.8",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "from": "aproba@1.1.1",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "from": "are-we-there-yet@1.1.4",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "from": "asn1@0.2.3",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "from": "assert-plus@0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "from": "asynckit@0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "aws4@1.6.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "from": "balanced-match@0.4.2",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "from": "bcrypt-pbkdf@1.0.1",
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "from": "block-stream@0.0.9",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+            },
+            "boom": {
+              "version": "2.10.1",
+              "from": "boom@2.10.1",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "from": "brace-expansion@1.1.7",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "buffer-shims@1.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "caseless@0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+            },
+            "co": {
+              "version": "4.6.0",
+              "from": "co@4.6.0",
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "from": "code-point-at@1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "from": "concat-map@0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "from": "console-control-strings@1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "from": "cryptiles@2.0.5",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "from": "deep-extend@0.4.2",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "from": "delayed-stream@1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "from": "delegates@1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "from": "ecc-jsbn@0.1.1",
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+            },
+            "extend": {
+              "version": "3.0.1",
+              "from": "extend@3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "from": "extsprintf@1.0.2",
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "from": "form-data@2.1.4",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "from": "fstream@1.0.11",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "from": "fstream-ignore@1.0.5",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "from": "gauge@2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+            },
+            "glob": {
+              "version": "7.1.2",
+              "from": "glob@7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "from": "har-schema@1.0.5",
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "har-validator@4.2.1",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "from": "has-unicode@2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "from": "hoek@2.16.3",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "ini": {
+              "version": "1.3.4",
+              "from": "ini@1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "from": "is-fullwidth-code-point@1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "from": "jodid25519@1.0.2",
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "from": "jsbn@0.1.1",
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "from": "json-schema@0.2.3",
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "json-stable-stringify@1.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "from": "mime-db@1.27.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "from": "mime-types@2.1.15",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+            },
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "from": "nopt@4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "from": "npmlog@4.1.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "from": "number-is-nan@1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "from": "os-homedir@1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "from": "os-tmpdir@1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "from": "osenv@0.1.4",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@0.2.0",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "from": "readable-stream@2.2.9",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+            },
+            "request": {
+              "version": "2.81.0",
+              "from": "request@2.81.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "from": "safe-buffer@5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "from": "set-blocking@2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "from": "signal-exit@3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "from": "sntp@1.0.9",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "from": "string-width@1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "from": "string_decoder@1.0.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "from": "strip-json-comments@2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@2.2.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "from": "tar-pack@3.4.0",
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "from": "tough-cookie@2.3.2",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "tunnel-agent@0.6.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "from": "tweetnacl@0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "from": "uid-number@0.0.6",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            },
+            "verror": {
+              "version": "1.3.6",
+              "from": "verror@1.3.6",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "from": "wide-align@1.1.2",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "from": "wrappy@1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "from": "rimraf@2.6.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+            },
+            "semver": {
+              "version": "5.3.0",
+              "from": "semver@5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "from": "uuid@3.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "from": "dashdash@1.14.1",
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "from": "getpass@0.1.7",
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "from": "jsprim@1.4.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "rc": {
+              "version": "1.2.1",
+              "from": "rc@1.2.1",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "from": "sshpk@1.13.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "cipher-base": {
       "version": "1.0.3",
-      "from": "cipher-base@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
-    },
-    "clarinet": {
-      "version": "0.11.0",
-      "from": "clarinet@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.11.0.tgz"
     },
     "cli": {
       "version": "1.0.0",
-      "from": "cli@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.5 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
     },
     "clone": {
       "version": "1.0.2",
-      "from": "clone@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-buffer": {
       "version": "1.0.0",
-      "from": "clone-buffer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "cloneable-readable": {
       "version": "1.0.0",
-      "from": "cloneable-readable@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@~1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@~2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@^2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@~4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "colors": {
       "version": "0.6.2",
-      "from": "colors@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "combine-lists": {
       "version": "1.0.1",
-      "from": "combine-lists@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz"
     },
     "combine-source-map": {
       "version": "0.3.0",
-      "from": "combine-source-map@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz"
     },
     "combined-stream": {
       "version": "0.0.7",
-      "from": "combined-stream@>=0.0.4 <0.1.0",
+      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
     },
     "commander": {
       "version": "1.3.2",
-      "from": "commander@1.3.2",
+      "from": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz"
     },
     "commondir": {
       "version": "0.0.1",
-      "from": "commondir@0.0.1",
+      "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
-      "from": "component-bind@1.0.0",
+      "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
     },
     "component-emitter": {
       "version": "1.1.2",
-      "from": "component-emitter@1.1.2",
+      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
     },
     "component-inherit": {
       "version": "0.0.3",
-      "from": "component-inherit@0.0.3",
+      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
+      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.4.10",
-      "from": "concat-stream@>=1.4.1 <1.5.0",
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
     },
     "concat-with-sourcemaps": {
       "version": "1.0.4",
-      "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "connect": {
       "version": "2.12.0",
-      "from": "connect@2.12.0",
+      "from": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz"
     },
     "connect-mongo": {
       "version": "0.4.2",
-      "from": "connect-mongo@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-0.4.2.tgz"
     },
     "connect-roles": {
       "version": "3.0.3",
-      "from": "connect-roles@>=3.0.3 <3.1.0",
+      "from": "https://registry.npmjs.org/connect-roles/-/connect-roles-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/connect-roles/-/connect-roles-3.0.3.tgz"
     },
     "console-browserify": {
       "version": "1.0.3",
-      "from": "console-browserify@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz"
     },
     "constants-browserify": {
       "version": "0.0.1",
-      "from": "constants-browserify@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
     },
     "content-type": {
       "version": "1.0.2",
-      "from": "content-type@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
       "version": "0.3.5",
-      "from": "convert-source-map@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
     },
     "cookie": {
       "version": "0.1.0",
-      "from": "cookie@0.1.0",
+      "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
     },
     "cookie-signature": {
       "version": "1.0.1",
-      "from": "cookie-signature@1.0.1",
+      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
     },
     "cookiejar": {
       "version": "2.1.0",
-      "from": "cookiejar@>=2.0.6 <3.0.0",
+      "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz"
     },
     "core-js": {
       "version": "2.4.1",
-      "from": "core-js@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "create-ecdh": {
       "version": "4.0.0",
-      "from": "create-ecdh@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
     },
     "create-hash": {
       "version": "1.1.2",
-      "from": "create-hash@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
     },
     "create-hmac": {
       "version": "1.1.4",
-      "from": "create-hmac@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
     },
     "cryptiles": {
       "version": "0.2.2",
-      "from": "cryptiles@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
     },
     "crypto-browserify": {
       "version": "1.0.9",
-      "from": "crypto-browserify@>=1.0.9 <1.1.0",
+      "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
     },
     "ctype": {
       "version": "0.5.3",
-      "from": "ctype@0.5.3",
+      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "custom-event": {
       "version": "1.0.1",
-      "from": "custom-event@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz"
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "cycle@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "dashdash": {
       "version": "1.14.0",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@>=1.0.11 <1.1.0",
+      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "0.8.1",
-      "from": "debug@>=0.7.3 <1.0.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-equal": {
       "version": "0.1.2",
-      "from": "deep-equal@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
-    },
-    "deep-keys": {
-      "version": "0.3.0",
-      "from": "deep-keys@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/deep-keys/-/deep-keys-0.3.0.tgz"
     },
     "deepmerge": {
       "version": "0.2.10",
-      "from": "deepmerge@>=0.2.10 <0.3.0",
+      "from": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz"
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "defaults@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "defined": {
       "version": "0.0.0",
-      "from": "defined@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
     },
     "delayed-stream": {
       "version": "0.0.5",
-      "from": "delayed-stream@0.0.5",
+      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
     },
     "depd": {
       "version": "1.1.0",
-      "from": "depd@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "deprecated": {
       "version": "0.0.1",
-      "from": "deprecated@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
     },
     "deps-sort": {
       "version": "0.1.2",
-      "from": "deps-sort@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.6.4",
-          "from": "JSONStream@>=0.6.4 <0.7.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
           "dependencies": {
             "through": {
               "version": "2.2.7",
-              "from": "through@>=2.2.7 <2.3.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
             }
           }
@@ -1036,2424 +1605,1986 @@
     },
     "derequire": {
       "version": "0.8.0",
-      "from": "derequire@>=0.8.0 <0.9.0",
+      "from": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz"
     },
     "des.js": {
       "version": "1.0.0",
-      "from": "des.js@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
     },
     "detect-file": {
       "version": "0.1.0",
-      "from": "detect-file@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz"
     },
     "detective": {
       "version": "3.1.0",
-      "from": "detective@>=3.1.0 <3.2.0",
+      "from": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz"
     },
     "di": {
       "version": "0.0.1",
-      "from": "di@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
     },
     "diff": {
       "version": "1.4.0",
-      "from": "diff@1.4.0",
+      "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "diffie-hellman": {
       "version": "5.0.2",
-      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
     },
     "dom-serialize": {
       "version": "2.2.1",
-      "from": "dom-serialize@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         },
         "entities": {
           "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "domain-browser": {
       "version": "1.1.7",
-      "from": "domain-browser@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
+      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
-      "from": "duplexer@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "duplexer2@0.0.2",
+      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "ee-first@1.1.1",
+      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "ejs": {
       "version": "2.5.2",
-      "from": "ejs@>=2.5.1 <3.0.0",
+      "from": "https://registry.npmjs.org/ejs/-/ejs-2.5.2.tgz",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.2.tgz"
     },
     "elliptic": {
       "version": "6.3.2",
-      "from": "elliptic@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz"
     },
     "email": {
       "version": "0.2.6",
-      "from": "email@>=0.2.6 <0.3.0",
+      "from": "https://registry.npmjs.org/email/-/email-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/email/-/email-0.2.6.tgz"
     },
     "end-of-stream": {
       "version": "0.1.5",
-      "from": "end-of-stream@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "dependencies": {
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
         }
       }
     },
     "engine.io": {
       "version": "1.6.10",
-      "from": "engine.io@1.6.10",
+      "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "ws": {
           "version": "1.0.1",
-          "from": "ws@1.0.1",
+          "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.9",
-      "from": "engine.io-client@1.6.9",
+      "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
         "ws": {
           "version": "1.0.1",
-          "from": "ws@1.0.1",
+          "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
-      "from": "engine.io-parser@1.2.4",
+      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
-          "from": "has-binary@0.1.6",
+          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
         }
       }
     },
     "ent": {
       "version": "2.2.0",
-      "from": "ent@>=2.2.0 <2.3.0",
+      "from": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
     },
     "entities": {
       "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "ert": {
       "version": "1.0.1",
-      "from": "ert@1.0.1",
+      "from": "https://registry.npmjs.org/ert/-/ert-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/ert/-/ert-1.0.1.tgz"
     },
     "es6-promise": {
       "version": "4.0.5",
-      "from": "es6-promise@>=4.0.3 <4.1.0",
+      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
       "version": "1.1.0",
-      "from": "escodegen@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "esprima@~1.0.4",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         }
       }
     },
     "escope": {
       "version": "0.0.16",
-      "from": "escope@>=0.0.13 <0.1.0",
+      "from": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz"
     },
     "esprima-fb": {
       "version": "3001.1.0-dev-harmony-fb",
-      "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3002.0.0",
+      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
     },
     "esrefactor": {
       "version": "0.1.0",
-      "from": "esrefactor@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "esprima@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "estraverse": {
           "version": "0.0.4",
-          "from": "estraverse@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
         }
       }
     },
     "estraverse": {
       "version": "1.5.1",
-      "from": "estraverse@>=1.5.0 <1.6.0",
+      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
     },
     "esutils": {
       "version": "1.0.0",
-      "from": "esutils@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
     },
     "event-stream": {
       "version": "3.3.4",
-      "from": "event-stream@>=3.1.7 <4.0.0",
+      "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz"
     },
     "eventemitter3": {
       "version": "1.2.0",
-      "from": "eventemitter3@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
     },
     "events": {
       "version": "1.0.2",
-      "from": "events@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
     },
     "evp_bytestokey": {
       "version": "1.0.0",
-      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
     },
     "exit": {
       "version": "0.1.2",
-      "from": "exit@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "expand-braces": {
       "version": "0.1.2",
-      "from": "expand-braces@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "dependencies": {
         "braces": {
           "version": "0.1.5",
-          "from": "braces@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz"
         },
         "expand-range": {
           "version": "0.1.1",
-          "from": "expand-range@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz"
         },
         "is-number": {
           "version": "0.1.1",
-          "from": "is-number@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
         },
         "repeat-string": {
           "version": "0.2.2",
-          "from": "repeat-string@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
         }
       }
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
+      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "expand-tilde": {
       "version": "1.2.2",
-      "from": "expand-tilde@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
     },
     "express": {
       "version": "3.4.8",
-      "from": "express@>=3.4.8 <3.5.0",
+      "from": "https://registry.npmjs.org/express/-/express-3.4.8.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-3.4.8.tgz"
     },
     "express-spa-router": {
       "version": "0.0.6",
-      "from": "express-spa-router@0.0.6",
+      "from": "https://registry.npmjs.org/express-spa-router/-/express-spa-router-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/express-spa-router/-/express-spa-router-0.0.6.tgz"
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-zip": {
       "version": "1.5.0",
-      "from": "extract-zip@>=1.5.0 <1.6.0",
+      "from": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.0",
-          "from": "concat-stream@1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz"
         },
         "debug": {
           "version": "0.7.4",
-          "from": "debug@0.7.4",
+          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "extsprintf": {
       "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
+      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "eyes@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fancy-log": {
       "version": "1.2.0",
-      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "faye-websocket": {
       "version": "0.7.3",
-      "from": "faye-websocket@>=0.7.2 <0.8.0",
+      "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz"
     },
     "fbgraph": {
       "version": "1.1.0",
-      "from": "fbgraph@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/fbgraph/-/fbgraph-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/fbgraph/-/fbgraph-1.1.0.tgz",
       "dependencies": {
-        "qs": {
-          "version": "1.2.2",
-          "from": "qs@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-        },
         "request": {
           "version": "2.40.0",
-          "from": "request@>=2.40.0 <2.41.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
           "dependencies": {
             "qs": {
               "version": "1.0.2",
-              "from": "qs@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
             }
           }
+        },
+        "qs": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         }
       }
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "feedparser": {
       "version": "0.16.6",
-      "from": "feedparser@>=0.16.6 <0.17.0",
+      "from": "https://registry.npmjs.org/feedparser/-/feedparser-0.16.6.tgz",
       "resolved": "https://registry.npmjs.org/feedparser/-/feedparser-0.16.6.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "filename-regex": {
       "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
       "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
+      "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         }
       }
     },
     "find-index": {
       "version": "0.1.1",
-      "from": "find-index@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "findup-sync": {
       "version": "0.4.2",
-      "from": "findup-sync@>=0.4.2 <0.5.0",
+      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz"
     },
     "fined": {
       "version": "1.0.1",
-      "from": "fined@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
       "dependencies": {
         "lodash.isarray": {
           "version": "4.0.0",
-          "from": "lodash.isarray@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz"
         }
       }
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "flagged-respawn": {
       "version": "0.3.2",
-      "from": "flagged-respawn@>=0.3.2 <0.4.0",
+      "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
     },
     "for-in": {
       "version": "0.1.6",
-      "from": "for-in@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
     },
     "for-own": {
       "version": "0.1.4",
-      "from": "for-own@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "foreach": {
       "version": "2.0.5",
-      "from": "foreach@>=2.0.1 <2.1.0",
+      "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.5.2",
-      "from": "forever-agent@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
     },
     "form-data": {
       "version": "0.1.4",
-      "from": "form-data@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz"
     },
     "formatio": {
       "version": "1.1.1",
-      "from": "formatio@1.1.1",
+      "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "formidable": {
       "version": "1.0.17",
-      "from": "formidable@>=1.0.14 <1.1.0",
+      "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
     "fresh": {
       "version": "0.2.0",
-      "from": "fresh@0.2.0",
+      "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
     },
     "from": {
       "version": "0.1.3",
-      "from": "from@>=0.0.0 <1.0.0",
+      "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
     },
     "fs-exists-sync": {
       "version": "0.1.0",
-      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
     },
     "fs-extra": {
       "version": "0.15.0",
-      "from": "fs-extra@>=0.15.0 <0.16.0",
+      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.15.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.15.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
         }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "gaze@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "glob": {
       "version": "3.2.11",
-      "from": "glob@>=3.2.9 <3.3.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
-      "from": "glob-stream@>=3.1.5 <4.0.0",
+      "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dependencies": {
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.3.1 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0-0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
-      "from": "glob-watcher@>=0.0.6 <0.0.7",
+      "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
       "version": "0.0.12",
-      "from": "glob2base@>=0.0.12 <0.0.13",
+      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "global-modules": {
       "version": "0.2.3",
-      "from": "global-modules@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
     },
     "global-prefix": {
       "version": "0.1.4",
-      "from": "global-prefix@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz"
     },
     "globule": {
       "version": "0.1.0",
-      "from": "globule@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
+        "lodash": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "graceful-fs@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
-          "from": "inherits@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "from": "lodash@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
-      "from": "glogg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@4.1.11",
+      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
+      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@1.9.2",
+      "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
     },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@>=3.9.0 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "gulp-browserify": {
       "version": "0.5.1",
-      "from": "gulp-browserify@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/gulp-browserify/-/gulp-browserify-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-browserify/-/gulp-browserify-0.5.1.tgz",
       "dependencies": {
+        "gulp-util": {
+          "version": "2.2.20",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "dependencies": {
+            "through2": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+            }
+          }
+        },
         "ansi-regex": {
           "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "from": "gulp-util@>=2.2.5 <2.3.0",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@>=1.0.17 <1.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            },
-            "through2": {
-              "version": "0.5.1",
-              "from": "through2@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
-            }
-          }
         },
         "has-ansi": {
           "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "lodash._reinterpolate": {
           "version": "2.4.1",
-          "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+          "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
         },
         "lodash.escape": {
           "version": "2.4.1",
-          "from": "lodash.escape@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
         },
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         },
         "lodash.template": {
           "version": "2.4.1",
-          "from": "lodash.template@>=2.4.1 <3.0.0",
+          "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz"
         },
         "lodash.templatesettings": {
           "version": "2.4.1",
-          "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
         },
         "minimist": {
           "version": "0.2.0",
-          "from": "minimist@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         },
         "vinyl": {
           "version": "0.2.3",
-          "from": "vinyl@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
         }
       }
     },
     "gulp-concat": {
       "version": "2.6.1",
-      "from": "gulp-concat@2.6.1",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "dependencies": {
-        "clone-stats": {
-          "version": "1.0.0",
-          "from": "clone-stats@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "from": "replace-ext@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "vinyl": {
           "version": "2.0.1",
-          "from": "vinyl@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz"
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0-0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "gulp-jshint": {
       "version": "1.12.0",
-      "from": "gulp-jshint@>=1.11.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.12.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.12.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0-0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        }
-      }
-    },
-    "gulp-jsoncombine": {
-      "version": "1.0.3",
-      "from": "gulp-jsoncombine@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-jsoncombine/-/gulp-jsoncombine-1.0.3.tgz",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "from": "gulp-util@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz"
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
-        },
-        "lodash._reinterpolate": {
-          "version": "2.4.1",
-          "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
-        },
-        "lodash.escape": {
-          "version": "2.4.1",
-          "from": "lodash.escape@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
-        },
-        "lodash.keys": {
-          "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-        },
-        "lodash.template": {
-          "version": "2.4.1",
-          "from": "lodash.template@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz"
-        },
-        "lodash.templatesettings": {
-          "version": "2.4.1",
-          "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
-        },
-        "minimist": {
-          "version": "0.2.0",
-          "from": "minimist@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.17 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-        },
-        "through2": {
-          "version": "0.5.1",
-          "from": "through2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
-        },
-        "vinyl": {
-          "version": "0.2.3",
-          "from": "vinyl@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+        "xtend": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "gulp-livereload": {
       "version": "3.8.1",
-      "from": "gulp-livereload@>=3.8.1 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-        },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "has-ansi": {
           "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         }
       }
     },
     "gulp-mocha": {
       "version": "2.2.0",
-      "from": "gulp-mocha@>=2.1.3 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz"
     },
     "gulp-plumber": {
       "version": "1.1.0",
-      "from": "gulp-plumber@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
       "dependencies": {
+        "through2": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "gulp-rename": {
       "version": "1.2.2",
-      "from": "gulp-rename@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+        },
+        "through2": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
-      "from": "gulplog@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@>=2.0.6 <2.1.0",
+      "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         }
       }
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-binary": {
       "version": "0.1.7",
-      "from": "has-binary@0.1.7",
+      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz"
     },
     "has-color": {
       "version": "0.1.7",
-      "from": "has-color@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "has-cors": {
       "version": "1.1.0",
-      "from": "has-cors@1.1.0",
+      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "from": "has-gulplog@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "hash.js": {
       "version": "1.0.3",
-      "from": "hash.js@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
     },
     "hasha": {
       "version": "2.2.0",
-      "from": "hasha@>=2.2.0 <2.3.0",
+      "from": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
     },
     "hat": {
       "version": "0.0.3",
-      "from": "hat@0.0.3",
+      "from": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz"
     },
     "hawk": {
       "version": "1.1.1",
-      "from": "hawk@1.1.1",
+      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
     },
     "hoek": {
       "version": "0.9.1",
-      "from": "hoek@>=0.9.0 <0.10.0",
+      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
     },
     "hooks": {
       "version": "0.2.1",
-      "from": "hooks@0.2.1",
+      "from": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
     },
     "html-entities": {
       "version": "1.1.3",
-      "from": "html-entities@>=1.1.1 <1.2.0",
+      "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz"
     },
     "htmlescape": {
       "version": "1.1.1",
-      "from": "htmlescape@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz"
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
+      "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
     },
     "http-browserify": {
       "version": "1.3.2",
-      "from": "http-browserify@>=1.3.1 <1.4.0",
+      "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz"
     },
     "http-errors": {
       "version": "1.3.1",
-      "from": "http-errors@>=1.3.1 <1.4.0",
+      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-proxy": {
       "version": "1.15.2",
-      "from": "http-proxy@>=1.13.0 <2.0.0",
+      "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz"
     },
     "http-signature": {
       "version": "0.10.1",
-      "from": "http-signature@>=0.10.0 <0.11.0",
+      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
     },
     "https-browserify": {
       "version": "0.0.1",
-      "from": "https-browserify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "https-proxy-agent": {
       "version": "1.0.0",
-      "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         }
       }
     },
     "iconv-lite": {
       "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
+      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
       "version": "1.1.6",
-      "from": "ieee754@>=1.1.1 <1.2.0",
+      "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "indexof": {
       "version": "0.0.1",
-      "from": "indexof@0.0.1",
+      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "inflight": {
       "version": "1.0.5",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.1 <2.1.0",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.4 <2.0.0",
+      "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-source-map": {
       "version": "0.3.1",
-      "from": "inline-source-map@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.3.0",
-          "from": "source-map@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz"
         }
       }
     },
     "insert-module-globals": {
       "version": "6.0.0",
-      "from": "insert-module-globals@>=6.0.0 <6.1.0",
+      "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
       "dependencies": {
         "process": {
           "version": "0.6.0",
-          "from": "process@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
         }
       }
     },
     "interpret": {
       "version": "1.0.1",
-      "from": "interpret@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
     },
     "interval-to-human": {
       "version": "0.1.1",
-      "from": "interval-to-human@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/interval-to-human/-/interval-to-human-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/interval-to-human/-/interval-to-human-0.1.1.tgz"
     },
     "irregular-plurals": {
       "version": "1.2.0",
-      "from": "irregular-plurals@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz"
     },
     "is": {
       "version": "0.2.7",
-      "from": "is@>=0.2.6 <0.3.0",
+      "from": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
       "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
     },
     "is-absolute": {
       "version": "0.2.5",
-      "from": "is-absolute@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
       "dependencies": {
         "is-windows": {
           "version": "0.1.1",
-          "from": "is-windows@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz"
         }
       }
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.4",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
-      "from": "is-finite@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "is-glob@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
       "version": "2.14.0",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-object": {
       "version": "0.1.2",
-      "from": "is-object@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-relative": {
       "version": "0.2.1",
-      "from": "is-relative@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-unc-path": {
       "version": "0.1.1",
-      "from": "is-unc-path@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-windows": {
       "version": "0.2.0",
-      "from": "is-windows@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isbinaryfile": {
       "version": "3.0.1",
-      "from": "isbinaryfile@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.1.tgz"
     },
     "isexe": {
       "version": "1.1.2",
-      "from": "isexe@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "0.26.3",
-      "from": "jade@0.26.3",
+      "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "from": "commander@0.6.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
-          "from": "mkdirp@0.3.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
     },
     "jasmine": {
       "version": "2.3.2",
-      "from": "jasmine@2.3.2",
+      "from": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz"
     },
     "jasmine-core": {
       "version": "2.3.4",
-      "from": "jasmine-core@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
     },
     "jasminewd": {
       "version": "1.1.0",
-      "from": "jasminewd@1.1.0",
+      "from": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
     },
     "jasminewd2": {
       "version": "0.0.6",
-      "from": "jasminewd2@0.0.6",
+      "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz"
     },
     "jmespath": {
       "version": "0.15.0",
-      "from": "jmespath@0.15.0",
+      "from": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-string-escape": {
       "version": "1.0.1",
-      "from": "js-string-escape@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
     },
     "jsbn": {
       "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jshint": {
       "version": "2.9.3",
-      "from": "jshint@>=2.7.0 <3.0.0",
+      "from": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
       "dependencies": {
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
-        },
-        "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <3.1.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         }
       }
     },
     "jsmin": {
       "version": "1.0.1",
-      "from": "jsmin@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz"
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@0.2.3",
+      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-stable-stringify": {
       "version": "0.0.1",
-      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.2.6",
-      "from": "json3@3.2.6",
+      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
     },
     "jsonfile": {
       "version": "2.4.0",
-      "from": "jsonfile@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonparse": {
       "version": "0.0.5",
-      "from": "jsonparse@0.0.5",
+      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
+      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-    },
-    "jsonstream": {
-      "version": "1.0.3",
-      "from": "jsonstream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonstream/-/jsonstream-1.0.3.tgz",
-      "dependencies": {
-        "jsonparse": {
-          "version": "1.0.0",
-          "from": "jsonparse@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
-        }
-      }
     },
     "jsprim": {
       "version": "1.3.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
-    },
-    "karma": {
-      "version": "1.3.0",
-      "from": "karma@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-1.3.0.tgz",
-      "dependencies": {
-        "bluebird": {
-          "version": "3.4.6",
-          "from": "bluebird@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
-        },
-        "colors": {
-          "version": "1.1.2",
-          "from": "colors@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-        },
-        "component-emitter": {
-          "version": "1.2.0",
-          "from": "component-emitter@1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
-        },
-        "connect": {
-          "version": "3.5.0",
-          "from": "connect@>=3.3.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "mime": {
-          "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "from": "range-parser@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-        },
-        "socket.io": {
-          "version": "1.4.7",
-          "from": "socket.io@1.4.7",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz"
-        },
-        "socket.io-client": {
-          "version": "1.4.6",
-          "from": "socket.io-client@1.4.6",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        }
-      }
-    },
-    "karma-browserify": {
-      "version": "4.4.2",
-      "from": "karma-browserify@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-4.4.2.tgz",
-      "dependencies": {
-        "JSONStream": {
-          "version": "1.2.1",
-          "from": "JSONStream@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz"
-        },
-        "acorn": {
-          "version": "3.3.0",
-          "from": "acorn@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-        },
-        "assert": {
-          "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
-        },
-        "browser-pack": {
-          "version": "5.0.1",
-          "from": "browser-pack@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz"
-        },
-        "browser-resolve": {
-          "version": "1.11.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
-        },
-        "browserify": {
-          "version": "10.2.3",
-          "from": "browserify@10.2.3",
-          "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.3.tgz"
-        },
-        "buffer": {
-          "version": "3.6.0",
-          "from": "buffer@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
-        },
-        "combine-source-map": {
-          "version": "0.6.1",
-          "from": "combine-source-map@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-          "dependencies": {
-            "convert-source-map": {
-              "version": "1.1.3",
-              "from": "convert-source-map@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
-            }
-          }
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
-        },
-        "crypto-browserify": {
-          "version": "3.11.0",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
-        },
-        "deep-equal": {
-          "version": "1.0.1",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
-        },
-        "defined": {
-          "version": "1.0.0",
-          "from": "defined@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-        },
-        "deps-sort": {
-          "version": "1.3.9",
-          "from": "deps-sort@>=1.3.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
-        },
-        "detective": {
-          "version": "4.3.2",
-          "from": "detective@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz"
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.0.5 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-            }
-          }
-        },
-        "http-browserify": {
-          "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
-        },
-        "inline-source-map": {
-          "version": "0.5.0",
-          "from": "inline-source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
-        },
-        "insert-module-globals": {
-          "version": "6.6.3",
-          "from": "insert-module-globals@>=6.4.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz"
-        },
-        "jsonparse": {
-          "version": "1.2.0",
-          "from": "jsonparse@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-        },
-        "lexical-scope": {
-          "version": "1.2.0",
-          "from": "lexical-scope@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@^3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "from": "minimatch@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz"
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "module-deps": {
-          "version": "3.9.1",
-          "from": "module-deps@>=3.7.11 <4.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz"
-        },
-        "parents": {
-          "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
-        },
-        "path-platform": {
-          "version": "0.11.15",
-          "from": "path-platform@>=0.11.15 <0.12.0",
-          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
-        },
-        "process": {
-          "version": "0.11.9",
-          "from": "process@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "from": "punycode@>=1.3.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-        },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "subarg": {
-          "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
-        },
-        "umd": {
-          "version": "3.0.1",
-          "from": "umd@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        }
-      }
-    },
-    "karma-chai-plugins": {
-      "version": "0.7.0",
-      "from": "karma-chai-plugins@>=0.7.0 <0.8.0",
-      "resolved": "https://registry.npmjs.org/karma-chai-plugins/-/karma-chai-plugins-0.7.0.tgz"
-    },
-    "karma-mocha": {
-      "version": "1.3.0",
-      "from": "karma-mocha@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        }
-      }
-    },
-    "karma-ng-html2js-preprocessor": {
-      "version": "1.0.0",
-      "from": "karma-ng-html2js-preprocessor@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-ng-html2js-preprocessor/-/karma-ng-html2js-preprocessor-1.0.0.tgz"
-    },
-    "karma-phantomjs-launcher": {
-      "version": "1.0.2",
-      "from": "karma-phantomjs-launcher@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.2.tgz"
     },
     "kerberos": {
       "version": "0.0.11",
-      "from": "kerberos@0.0.11",
+      "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz",
       "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz"
     },
     "kew": {
       "version": "0.7.0",
-      "from": "kew@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
     },
     "keypress": {
       "version": "0.1.0",
-      "from": "keypress@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
     },
     "kind-of": {
       "version": "3.0.4",
-      "from": "kind-of@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
     },
     "klaw": {
       "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
     },
     "labeled-stream-splicer": {
       "version": "1.0.2",
-      "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "lexical-scope": {
       "version": "1.1.1",
-      "from": "lexical-scope@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz"
     },
     "liftoff": {
       "version": "2.3.0",
-      "from": "liftoff@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "from": "resolve@>=1.1.7 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         }
       }
     },
     "livereload-js": {
       "version": "2.2.2",
-      "from": "livereload-js@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "locale": {
       "version": "0.0.20",
-      "from": "locale@0.0.20",
+      "from": "https://registry.npmjs.org/locale/-/locale-0.0.20.tgz",
       "resolved": "https://registry.npmjs.org/locale/-/locale-0.0.20.tgz"
     },
     "lodash": {
       "version": "4.17.2",
-      "from": "lodash@4.17.2",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._escapehtmlchar": {
       "version": "2.4.1",
-      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz"
     },
     "lodash._escapestringchar": {
       "version": "2.4.1",
-      "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._htmlescapes": {
       "version": "2.4.1",
-      "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._isnative": {
       "version": "2.4.1",
-      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
     },
     "lodash._objecttypes": {
       "version": "2.4.1",
-      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._reunescapedhtml": {
       "version": "2.4.1",
-      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
     "lodash._root": {
       "version": "3.0.1",
-      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
     "lodash._shimkeys": {
       "version": "2.4.1",
-      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
     },
     "lodash.assign": {
       "version": "3.2.0",
-      "from": "lodash.assign@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
     },
     "lodash.assignwith": {
       "version": "4.2.0",
-      "from": "lodash.assignwith@>=4.0.7 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz"
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
     },
     "lodash.defaults": {
       "version": "2.4.1",
-      "from": "lodash.defaults@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "from": "lodash.isempty@>=4.2.1 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz"
     },
     "lodash.isobject": {
       "version": "2.4.1",
-      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "from": "lodash.isplainobject@>=4.0.4 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "from": "lodash.isstring@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "from": "lodash.mapvalues@>=4.4.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
     },
     "lodash.memoize": {
       "version": "3.0.4",
-      "from": "lodash.memoize@>=3.0.3 <3.1.0",
+      "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "from": "lodash.pick@>=4.2.1 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
-      "from": "lodash.template@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.values": {
       "version": "2.4.1",
-      "from": "lodash.values@>=2.4.1 <2.5.0",
+      "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
     "log4js": {
       "version": "0.6.38",
-      "from": "log4js@>=0.6.31 <0.7.0",
+      "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.3 <4.4.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "lolex": {
       "version": "1.3.2",
-      "from": "lolex@1.3.2",
+      "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
     "lru-cache": {
       "version": "2.7.3",
-      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "map-cache": {
       "version": "0.2.2",
-      "from": "map-cache@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "map-stream": {
       "version": "0.1.0",
-      "from": "map-stream@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "media-typer@0.3.0",
+      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.3.0 <4.0.0",
+      "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "merge-descriptors": {
       "version": "0.0.1",
-      "from": "merge-descriptors@0.0.1",
+      "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz"
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "from": "merge-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        }
-      }
     },
     "methods": {
       "version": "0.1.0",
-      "from": "methods@0.1.0",
+      "from": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
     },
     "micromatch": {
       "version": "2.3.11",
-      "from": "micromatch@>=2.3.7 <3.0.0",
+      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
     },
     "migrate": {
       "version": "0.2.3",
-      "from": "migrate@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/migrate/-/migrate-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/migrate/-/migrate-0.2.3.tgz"
     },
     "miller-rabin": {
       "version": "4.0.0",
-      "from": "miller-rabin@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
     },
     "mime": {
       "version": "1.2.11",
-      "from": "mime@>=1.2.9 <1.3.0",
+      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
     },
     "mime-db": {
       "version": "1.24.0",
-      "from": "mime-db@>=1.24.0 <1.25.0",
+      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
     },
     "mime-types": {
       "version": "1.0.2",
-      "from": "mime-types@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
     },
     "mini-lr": {
       "version": "0.1.9",
-      "from": "mini-lr@>=0.1.8 <0.2.0",
+      "from": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
       "resolved": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "qs": {
           "version": "2.2.5",
-          "from": "qs@>=2.2.3 <2.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz"
         }
       }
     },
     "minijasminenode": {
       "version": "1.1.1",
-      "from": "minijasminenode@1.1.1",
+      "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
     },
     "minimalistic-assert": {
       "version": "1.0.0",
-      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
     },
     "minimatch": {
@@ -3463,118 +3594,81 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "from": "minimist@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "mkdirp@0.3.5",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-    },
-    "mocha": {
-      "version": "2.5.3",
-      "from": "mocha@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "from": "commander@2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "supports-color": {
-          "version": "1.2.0",
-          "from": "supports-color@1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-        }
-      }
     },
     "module-deps": {
       "version": "2.0.6",
-      "from": "module-deps@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/module-deps/-/module-deps-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-2.0.6.tgz",
       "dependencies": {
         "parents": {
           "version": "0.0.2",
-          "from": "parents@0.0.2",
+          "from": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz"
         },
         "stream-combiner": {
           "version": "0.1.0",
-          "from": "stream-combiner@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.1.0.tgz"
         }
       }
     },
     "moment": {
       "version": "2.8.4",
-      "from": "moment@>=2.8.4 <2.9.0",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
     },
     "mongodb": {
       "version": "1.4.40",
-      "from": "mongodb@>=1.4.0 <1.5.0",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.40.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.40.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.2.2",
-          "from": "readable-stream@latest",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "mongoose": {
       "version": "3.8.40",
-      "from": "mongoose@>=3.8.23 <3.9.0",
+      "from": "https://registry.npmjs.org/mongoose/-/mongoose-3.8.40.tgz",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.8.40.tgz",
       "dependencies": {
         "mongodb": {
           "version": "1.4.38",
-          "from": "mongodb@1.4.38",
+          "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.38.tgz",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.38.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.2.2",
-              "from": "readable-stream@latest",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
               "dependencies": {
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@~1.0.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
@@ -3583,1073 +3677,929 @@
         },
         "ms": {
           "version": "0.1.0",
-          "from": "ms@0.1.0",
+          "from": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz"
         }
       }
     },
     "mongoose-auto-increment": {
       "version": "3.2.4",
-      "from": "mongoose-auto-increment@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-3.2.4.tgz",
       "resolved": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-3.2.4.tgz",
       "dependencies": {
         "extend": {
           "version": "2.0.1",
-          "from": "extend@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
         }
       }
     },
     "mongoose-listento": {
       "version": "0.0.4",
-      "from": "mongoose-listento@0.0.4",
+      "from": "https://registry.npmjs.org/mongoose-listento/-/mongoose-listento-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/mongoose-listento/-/mongoose-listento-0.0.4.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.7.0",
-          "from": "underscore@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
         }
       }
     },
     "mongoose-validator": {
       "version": "1.2.5",
-      "from": "mongoose-validator@>=1.2.4 <2.0.0",
+      "from": "https://registry.npmjs.org/mongoose-validator/-/mongoose-validator-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/mongoose-validator/-/mongoose-validator-1.2.5.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.3 <2.0.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         },
         "validator": {
           "version": "4.9.0",
-          "from": "validator@>=4.0.2 <5.0.0",
+          "from": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz"
         }
       }
     },
     "mpath": {
       "version": "0.1.1",
-      "from": "mpath@0.1.1",
+      "from": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
     },
     "mpromise": {
       "version": "0.4.3",
-      "from": "mpromise@0.4.3",
+      "from": "https://registry.npmjs.org/mpromise/-/mpromise-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.4.3.tgz"
     },
     "mquery": {
       "version": "1.10.0",
-      "from": "mquery@1.10.0",
+      "from": "https://registry.npmjs.org/mquery/-/mquery-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.10.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         }
       }
     },
     "ms": {
       "version": "0.7.1",
-      "from": "ms@0.7.1",
+      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multiparty": {
       "version": "2.2.0",
-      "from": "multiparty@2.2.0",
+      "from": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz"
     },
     "multipipe": {
       "version": "0.1.2",
-      "from": "multipipe@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
     "muri": {
       "version": "1.1.0",
-      "from": "muri@1.1.0",
+      "from": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz"
     },
     "nan": {
       "version": "1.8.4",
-      "from": "nan@>=1.8.0 <1.9.0",
+      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
     },
     "natives": {
       "version": "1.1.0",
-      "from": "natives@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
     },
     "nconf": {
       "version": "0.7.2",
-      "from": "nconf@>=0.7.1 <0.8.0",
+      "from": "https://registry.npmjs.org/nconf/-/nconf-0.7.2.tgz",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.7.2.tgz",
       "dependencies": {
-        "window-size": {
-          "version": "0.1.4",
-          "from": "window-size@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
-        },
         "yargs": {
           "version": "3.15.0",
-          "from": "yargs@>=3.15.0 <3.16.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz"
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
         }
       }
     },
     "negotiator": {
       "version": "0.3.0",
-      "from": "negotiator@0.3.0",
+      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
-    },
-    "ng-html2js": {
-      "version": "2.0.0",
-      "from": "ng-html2js@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ng-html2js/-/ng-html2js-2.0.0.tgz"
     },
     "node-sass": {
       "version": "0.8.6",
-      "from": "node-sass@>=0.8.6 <0.9.0",
+      "from": "https://registry.npmjs.org/node-sass/-/node-sass-0.8.6.tgz",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-0.8.6.tgz",
       "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "from": "ansi-styles@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
+        },
+        "nan": {
+          "version": "0.8.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
+        },
+        "mocha": {
+          "version": "1.18.2",
+          "from": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
         },
         "commander": {
           "version": "2.0.0",
-          "from": "commander@2.0.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
         },
         "diff": {
           "version": "1.0.7",
-          "from": "diff@1.0.7",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "glob@3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz"
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "graceful-fs@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
-        },
-        "mocha": {
-          "version": "1.18.2",
-          "from": "mocha@>=1.18.0 <1.19.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz"
-        },
-        "nan": {
-          "version": "0.8.0",
-          "from": "nan@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "from": "strip-ansi@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
         }
       }
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@>=1.4.0 <1.5.0",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "node-watch": {
       "version": "0.3.5",
-      "from": "node-watch@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.5.tgz"
     },
     "nodemailer": {
       "version": "2.3.2",
-      "from": "nodemailer@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.3.2.tgz",
       "dependencies": {
-        "addressparser": {
-          "version": "1.0.1",
-          "from": "addressparser@1.0.1",
-          "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz"
-        },
-        "buildmail": {
-          "version": "3.6.0",
-          "from": "buildmail@3.6.0",
-          "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-3.6.0.tgz"
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-        },
-        "ip": {
-          "version": "1.1.2",
-          "from": "ip@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.2.tgz"
-        },
-        "libbase64": {
-          "version": "0.1.0",
-          "from": "libbase64@0.1.0",
-          "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
-        },
         "libmime": {
           "version": "2.0.3",
-          "from": "libmime@2.0.3",
+          "from": "https://registry.npmjs.org/libmime/-/libmime-2.0.3.tgz",
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-2.0.3.tgz"
-        },
-        "libqp": {
-          "version": "1.1.0",
-          "from": "libqp@1.1.0",
-          "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz"
         },
         "mailcomposer": {
           "version": "3.7.0",
-          "from": "mailcomposer@3.7.0",
+          "from": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-3.7.0.tgz"
         },
         "nodemailer-direct-transport": {
           "version": "3.0.7",
-          "from": "nodemailer-direct-transport@3.0.7",
+          "from": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.0.7.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.0.7.tgz"
-        },
-        "nodemailer-fetch": {
-          "version": "1.3.0",
-          "from": "nodemailer-fetch@1.3.0",
-          "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.3.0.tgz"
         },
         "nodemailer-shared": {
           "version": "1.0.4",
-          "from": "nodemailer-shared@1.0.4",
+          "from": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.0.4.tgz"
         },
         "nodemailer-smtp-pool": {
           "version": "2.5.2",
-          "from": "nodemailer-smtp-pool@2.5.2",
+          "from": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.5.2.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.5.2.tgz"
         },
         "nodemailer-smtp-transport": {
           "version": "2.4.2",
-          "from": "nodemailer-smtp-transport@2.4.2",
+          "from": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.4.2.tgz"
+        },
+        "socks": {
+          "version": "1.1.9",
+          "from": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz"
+        },
+        "addressparser": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz"
+        },
+        "buildmail": {
+          "version": "3.6.0",
+          "from": "https://registry.npmjs.org/buildmail/-/buildmail-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-3.6.0.tgz"
+        },
+        "ip": {
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/ip/-/ip-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.2.tgz"
+        },
+        "libbase64": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
+        },
+        "libqp": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz"
+        },
+        "nodemailer-fetch": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.3.0.tgz"
         },
         "nodemailer-wellknown": {
           "version": "0.1.8",
-          "from": "nodemailer-wellknown@0.1.8",
+          "from": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.8.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.8.tgz"
         },
         "smart-buffer": {
           "version": "1.0.4",
-          "from": "smart-buffer@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.0.4.tgz"
         },
         "smtp-connection": {
           "version": "2.3.2",
-          "from": "smtp-connection@2.3.2",
+          "from": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.3.2.tgz"
-        },
-        "socks": {
-          "version": "1.1.9",
-          "from": "socks@1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz"
         }
       }
     },
     "nodemailer-sendgrid-transport": {
       "version": "0.2.0",
-      "from": "nodemailer-sendgrid-transport@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz"
     },
     "nodemailer-ses-transport": {
       "version": "1.5.0",
-      "from": "nodemailer-ses-transport@1.5.0",
+      "from": "https://registry.npmjs.org/nodemailer-ses-transport/-/nodemailer-ses-transport-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer-ses-transport/-/nodemailer-ses-transport-1.5.0.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth": {
       "version": "0.9.9",
-      "from": "oauth@0.9.9",
+      "from": "https://registry.npmjs.org/oauth/-/oauth-0.9.9.tgz",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.9.tgz"
     },
     "oauth-sign": {
       "version": "0.3.0",
-      "from": "oauth-sign@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-component": {
       "version": "0.0.3",
-      "from": "object-component@0.0.3",
+      "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
     },
     "object-keys": {
       "version": "0.4.0",
-      "from": "object-keys@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
-      "from": "object.omit@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "optimist": {
       "version": "0.3.7",
-      "from": "optimist@>=0.3.5 <0.4.0",
+      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
     },
     "options": {
       "version": "0.0.6",
-      "from": "options@>=0.0.5",
+      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "orchestrator": {
       "version": "0.3.7",
-      "from": "orchestrator@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz"
     },
     "ordered-read-streams": {
       "version": "0.1.0",
-      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
     },
     "os-browserify": {
       "version": "0.1.2",
-      "from": "os-browserify@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
-      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-shim": {
       "version": "0.1.3",
-      "from": "os-shim@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
-      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "osenv": {
       "version": "0.1.3",
-      "from": "osenv@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
     "outpipe": {
       "version": "1.1.1",
-      "from": "outpipe@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
       "dependencies": {
         "shell-quote": {
           "version": "1.6.1",
-          "from": "shell-quote@>=1.4.2 <2.0.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz"
         }
       }
     },
     "pako": {
       "version": "0.2.9",
-      "from": "pako@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "parents": {
       "version": "0.0.3",
-      "from": "parents@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz"
     },
     "parse-asn1": {
       "version": "5.0.0",
-      "from": "parse-asn1@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
     },
     "parse-filepath": {
       "version": "1.0.1",
-      "from": "parse-filepath@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parsejson": {
       "version": "0.0.1",
-      "from": "parsejson@0.0.1",
+      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
     },
     "parseqs": {
       "version": "0.0.2",
-      "from": "parseqs@0.0.2",
+      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
     },
     "parseuri": {
       "version": "0.0.4",
-      "from": "parseuri@0.0.4",
+      "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
-      "from": "parseurl@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "passport": {
       "version": "0.2.2",
-      "from": "passport@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/passport/-/passport-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.2.tgz"
     },
     "passport-local": {
       "version": "1.0.0",
-      "from": "passport-local@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz"
     },
     "passport-strategy": {
       "version": "1.0.0",
-      "from": "passport-strategy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
     },
     "passport.socketio": {
       "version": "3.0.1",
-      "from": "passport.socketio@>=3.0.1 <3.1.0",
+      "from": "https://registry.npmjs.org/passport.socketio/-/passport.socketio-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/passport.socketio/-/passport.socketio-3.0.1.tgz",
       "dependencies": {
-        "object-keys": {
-          "version": "0.2.0",
-          "from": "object-keys@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz"
-        },
         "xtend": {
           "version": "2.0.6",
-          "from": "xtend@>=2.0.3 <2.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz"
+        },
+        "object-keys": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz"
         }
       }
     },
     "path-browserify": {
       "version": "0.0.0",
-      "from": "path-browserify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-platform": {
       "version": "0.0.1",
-      "from": "path-platform@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
     },
     "path-root": {
       "version": "0.1.1",
-      "from": "path-root@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
     },
     "path-root-regex": {
       "version": "0.1.2",
-      "from": "path-root-regex@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
     },
     "path-to-regexp": {
       "version": "0.1.2",
-      "from": "path-to-regexp@0.1.2",
+      "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pause": {
       "version": "0.0.1",
-      "from": "pause@0.0.1",
+      "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
     },
     "pause-stream": {
       "version": "0.0.11",
-      "from": "pause-stream@0.0.11",
+      "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pbkdf2": {
       "version": "3.0.9",
-      "from": "pbkdf2@>=3.0.3 <4.0.0",
+      "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
     },
     "pend": {
       "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "phantomjs-prebuilt": {
       "version": "2.1.13",
-      "from": "phantomjs-prebuilt@>=2.1.7 <3.0.0",
+      "from": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+        "fs-extra": {
+          "version": "0.30.0",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz"
+        },
+        "request": {
+          "version": "2.74.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
         },
         "async": {
           "version": "2.1.2",
-          "from": "async@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "boom": {
           "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc4 <1.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "from": "fs-extra@>=0.30.0 <0.31.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.2.1",
-          "from": "qs@>=6.2.0 <6.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
-        },
-        "request": {
-          "version": "2.74.0",
-          "from": "request@>=2.74.0 <2.75.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pkginfo": {
       "version": "0.3.1",
-      "from": "pkginfo@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
     },
     "plur": {
       "version": "2.1.2",
-      "from": "plur@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz"
     },
     "policyfile": {
       "version": "0.0.4",
-      "from": "policyfile@0.0.4",
+      "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
       "version": "1.0.2",
-      "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
     },
     "process": {
       "version": "0.7.0",
-      "from": "process@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/process/-/process-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <1.2.0",
+      "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "4.0.0",
-      "from": "promise@>=4.0.0 <4.1.0",
+      "from": "https://registry.npmjs.org/promise/-/promise-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/promise/-/promise-4.0.0.tgz"
-    },
-    "protractor": {
-      "version": "2.5.1",
-      "from": "protractor@>=2.5.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-2.5.1.tgz",
-      "dependencies": {
-        "bl": {
-          "version": "0.9.5",
-          "from": "bl@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "caseless": {
-          "version": "0.10.0",
-          "from": "caseless@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.8.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "dependencies": {
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
-            },
-            "delayed-stream": {
-              "version": "0.0.5",
-              "from": "delayed-stream@0.0.5",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-            }
-          }
-        },
-        "har-validator": {
-          "version": "1.8.0",
-          "from": "har-validator@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz"
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "http-signature": {
-          "version": "0.11.0",
-          "from": "http-signature@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "from": "mime-types@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@~0.6.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-        },
-        "qs": {
-          "version": "3.1.0",
-          "from": "qs@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@~1.0.26",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "request": {
-          "version": "2.57.0",
-          "from": "request@>=2.57.0 <2.58.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz"
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        }
-      }
     },
     "public-encrypt": {
       "version": "4.0.0",
-      "from": "public-encrypt@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
     },
     "punycode": {
       "version": "1.2.4",
-      "from": "punycode@>=1.2.3 <1.3.0",
+      "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
     },
     "q": {
       "version": "1.0.0",
-      "from": "q@1.0.0",
+      "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
     },
     "qjobs": {
       "version": "1.1.5",
-      "from": "qjobs@>=1.1.4 <2.0.0",
+      "from": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz"
     },
     "qs": {
       "version": "0.6.6",
-      "from": "qs@0.6.6",
+      "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
     },
     "querystring": {
       "version": "0.2.0",
-      "from": "querystring@0.2.0",
+      "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
       "version": "0.2.0",
-      "from": "querystring-es3@0.2.0",
+      "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
-      "from": "randomatic@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "randombytes": {
       "version": "2.0.3",
-      "from": "randombytes@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
     },
     "range-parser": {
       "version": "0.0.4",
-      "from": "range-parser@0.0.4",
+      "from": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
     },
     "raw-body": {
       "version": "1.1.2",
-      "from": "raw-body@1.1.2",
+      "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
     },
     "rcfinder": {
       "version": "0.1.9",
-      "from": "rcfinder@>=0.1.6 <0.2.0",
+      "from": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.9.tgz",
       "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.9.tgz"
     },
     "rcloader": {
       "version": "0.1.2",
-      "from": "rcloader@0.1.2",
+      "from": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "read-only-stream": {
       "version": "1.1.1",
-      "from": "read-only-stream@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "1.1.14",
-      "from": "readable-stream@>=1.1.9 <1.2.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "dependencies": {
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "readable-wrap": {
       "version": "1.0.0",
-      "from": "readable-wrap@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         },
         "readable-stream": {
           "version": "2.1.5",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.2 <0.7.0",
+      "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "from": "resolve@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         }
       }
     },
     "redent": {
       "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "redis": {
       "version": "0.7.3",
-      "from": "redis@0.7.3",
+      "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
       "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "regexp-clone": {
       "version": "0.0.1",
-      "from": "regexp-clone@0.0.1",
+      "from": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
     },
     "remove-trailing-separator": {
       "version": "1.0.1",
-      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.4",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
+      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.34.0",
-      "from": "request@>=2.34.0 <2.35.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
       "dependencies": {
-        "hawk": {
-          "version": "1.0.0",
-          "from": "hawk@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz"
-        },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+        },
+        "hawk": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz"
         }
       }
     },
     "request-progress": {
       "version": "2.0.1",
-      "from": "request-progress@>=2.0.1 <2.1.0",
+      "from": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz"
     },
     "requires-port": {
       "version": "1.0.0",
-      "from": "requires-port@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resanitize": {
       "version": "0.3.0",
-      "from": "resanitize@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/resanitize/-/resanitize-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/resanitize/-/resanitize-0.3.0.tgz"
     },
     "resolve": {
@@ -4659,497 +4609,490 @@
     },
     "resolve-dir": {
       "version": "0.1.1",
-      "from": "resolve-dir@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
     },
     "rfile": {
       "version": "1.0.0",
-      "from": "rfile@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
       "dependencies": {
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.4",
-      "from": "rimraf@>=2.2.8 <3.0.0",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.5 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "ripemd160": {
       "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
     },
     "ruglify": {
       "version": "1.0.0",
-      "from": "ruglify@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
       "dependencies": {
         "uglify-js": {
           "version": "2.2.5",
-          "from": "uglify-js@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz"
         }
       }
     },
+    "rwlock": {
+      "version": "5.0.0",
+      "from": "rwlock@latest",
+      "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz"
+    },
     "samsam": {
       "version": "1.1.2",
-      "from": "samsam@1.1.2",
+      "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
     },
     "saucelabs": {
       "version": "1.0.1",
-      "from": "saucelabs@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz"
     },
     "sax": {
       "version": "0.5.8",
-      "from": "sax@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
     },
     "selenium-webdriver": {
       "version": "2.47.0",
-      "from": "selenium-webdriver@2.47.0",
+      "from": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.47.0.tgz",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.47.0.tgz",
       "dependencies": {
-        "sax": {
-          "version": "0.6.1",
-          "from": "sax@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
-        },
         "tmp": {
           "version": "0.0.24",
-          "from": "tmp@0.0.24",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
         },
         "ws": {
           "version": "0.8.1",
-          "from": "ws@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz",
           "resolved": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz"
         },
         "xml2js": {
           "version": "0.4.4",
-          "from": "xml2js@0.4.4",
+          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz"
+        },
+        "sax": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
         }
       }
     },
     "semver": {
       "version": "5.3.0",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "send": {
       "version": "0.1.4",
-      "from": "send@0.1.4",
+      "from": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz"
     },
     "sendgrid": {
       "version": "1.9.2",
-      "from": "sendgrid@>=1.8.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sendgrid/-/sendgrid-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/sendgrid/-/sendgrid-1.9.2.tgz",
       "dependencies": {
+        "request": {
+          "version": "2.75.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
         "assert-plus": {
           "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "boom": {
           "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "2.0.0",
-          "from": "form-data@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.0.1 <4.0.0||>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.2.1",
-          "from": "qs@>=6.2.0 <6.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
-        },
-        "request": {
-          "version": "2.75.0",
-          "from": "request@>=2.60.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         }
       }
     },
     "sequencify": {
       "version": "0.0.7",
-      "from": "sequencify@>=0.0.7 <0.1.0",
+      "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "sha.js": {
       "version": "2.4.5",
-      "from": "sha.js@>=2.3.6 <3.0.0",
+      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
     },
     "shallow-copy": {
       "version": "0.0.1",
-      "from": "shallow-copy@0.0.1",
+      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
     },
     "shasum": {
       "version": "1.0.2",
-      "from": "shasum@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz"
     },
     "shell-quote": {
       "version": "0.0.1",
-      "from": "shell-quote@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
     },
     "shelljs": {
       "version": "0.3.0",
-      "from": "shelljs@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "3.0.1",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
     },
     "single-line-log": {
       "version": "0.4.1",
-      "from": "single-line-log@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz"
     },
     "sinon": {
       "version": "1.17.6",
-      "from": "sinon@>=1.9.1 <2.0.0",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.6.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.6.tgz"
     },
     "sinon-chai": {
       "version": "2.8.0",
-      "from": "sinon-chai@>=2.8.0 <3.0.0",
+      "from": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz"
     },
     "sliced": {
       "version": "0.0.5",
-      "from": "sliced@0.0.5",
+      "from": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
     },
     "smtpapi": {
       "version": "1.2.0",
-      "from": "smtpapi@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/smtpapi/-/smtpapi-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/smtpapi/-/smtpapi-1.2.0.tgz"
     },
     "sntp": {
       "version": "0.2.4",
-      "from": "sntp@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
     },
     "socket.io": {
       "version": "0.9.17",
-      "from": "socket.io@>=0.9.16 <0.10.0",
+      "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
       "dependencies": {
         "socket.io-client": {
           "version": "0.9.16",
-          "from": "socket.io-client@0.9.16",
+          "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz"
         },
         "uglify-js": {
           "version": "1.2.5",
-          "from": "uglify-js@1.2.5",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
         }
       }
     },
     "socket.io-adapter": {
       "version": "0.4.0",
-      "from": "socket.io-adapter@0.4.0",
+      "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "socket.io-parser": {
           "version": "2.2.2",
-          "from": "socket.io-parser@2.2.2",
+          "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "dependencies": {
             "debug": {
               "version": "0.7.4",
-              "from": "debug@0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         }
       }
     },
-    "socket.io-client": {
-      "version": "0.9.17",
-      "from": "socket.io-client@>=0.9.16 <0.10.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.17.tgz",
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.2.5",
-          "from": "uglify-js@1.2.5",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
-        }
-      }
-    },
     "socket.io-parser": {
       "version": "2.2.6",
-      "from": "socket.io-parser@2.2.6",
+      "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "json3": {
           "version": "3.3.2",
-          "from": "json3@3.3.2",
+          "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
           "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
         }
       }
     },
     "source-map": {
       "version": "0.1.43",
-      "from": "source-map@>=0.1.31 <0.2.0",
+      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
-      "from": "source-map-support@>=0.2.6 <0.3.0",
+      "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
-          "from": "source-map@0.1.32",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "sparkles": {
       "version": "1.0.0",
-      "from": "sparkles@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.3",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "split": {
       "version": "0.3.3",
-      "from": "split@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
     },
     "sshpk": {
       "version": "1.10.0",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "statuses": {
       "version": "1.3.0",
-      "from": "statuses@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
     },
     "stream-browserify": {
       "version": "0.1.3",
-      "from": "stream-browserify@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
       "dependencies": {
         "process": {
           "version": "0.5.2",
-          "from": "process@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
         }
       }
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "from": "stream-combiner@>=0.0.2 <0.1.0",
+      "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
     },
     "stream-combiner2": {
       "version": "1.0.2",
-      "from": "stream-combiner2@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "dependencies": {
+        "through2": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+        },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.17 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "0.5.1",
-          "from": "through2@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
         }
       }
     },
     "stream-consume": {
       "version": "0.1.0",
-      "from": "stream-consume@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
     },
     "stream-counter": {
       "version": "0.2.0",
-      "from": "stream-counter@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
     },
     "stream-splicer": {
       "version": "1.3.2",
-      "from": "stream-splicer@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
       "dependencies": {
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0-0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "strformat": {
       "version": "0.0.3",
-      "from": "strformat@0.0.3",
+      "from": "https://registry.npmjs.org/strformat/-/strformat-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/strformat/-/strformat-0.0.3.tgz"
     },
     "string": {
       "version": "3.0.1",
-      "from": "string@>=3.0.0 <3.1.0",
+      "from": "https://registry.npmjs.org/string/-/string-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/string/-/string-3.0.1.tgz"
     },
     "string_decoder": {
@@ -5159,155 +5102,143 @@
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
+      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "subarg": {
       "version": "0.0.1",
-      "from": "subarg@0.0.1",
+      "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz"
     },
     "superagent": {
       "version": "2.3.0",
-      "from": "superagent@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "from": "component-emitter@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc4",
-          "from": "form-data@1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "methods": {
-          "version": "1.1.2",
-          "from": "methods@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+        "qs": {
+          "version": "6.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@1.3.4",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
-        "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@>=2.1.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+        "component-emitter": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
         },
-        "qs": {
-          "version": "6.3.0",
-          "from": "qs@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+        "methods": {
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
         },
         "readable-stream": {
           "version": "2.1.5",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "async": {
+          "version": "1.5.2",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.12",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        }
-      }
-    },
-    "supertest": {
-      "version": "2.0.1",
-      "from": "supertest@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.1.tgz",
-      "dependencies": {
-        "methods": {
-          "version": "1.1.2",
-          "from": "methods@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         }
       }
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "syntax-error": {
       "version": "1.1.6",
-      "from": "syntax-error@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.7.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
     "temp": {
       "version": "0.8.3",
-      "from": "temp@>=0.8.3 <0.9.0",
+      "from": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.6 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "throttleit": {
       "version": "1.0.0",
-      "from": "throttleit@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.2.7 <3.0.0",
+      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -5315,6 +5246,354 @@
       "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        }
+      }
+    },
+    "tildify": {
+      "version": "1.2.0",
+      "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
+    },
+    "time-stamp": {
+      "version": "1.0.1",
+      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
+    },
+    "timekeeper": {
+      "version": "0.0.4",
+      "from": "https://registry.npmjs.org/timekeeper/-/timekeeper-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-0.0.4.tgz"
+    },
+    "timers-browserify": {
+      "version": "1.0.3",
+      "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+        }
+      }
+    },
+    "timezone": {
+      "version": "0.0.32",
+      "from": "https://registry.npmjs.org/timezone/-/timezone-0.0.32.tgz",
+      "resolved": "https://registry.npmjs.org/timezone/-/timezone-0.0.32.tgz"
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+    },
+    "tmp": {
+      "version": "0.0.28",
+      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "from": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.1",
+      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
+    "tweet-matches": {
+      "version": "1.0.1",
+      "from": "https://registry.npmjs.org/tweet-matches/-/tweet-matches-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tweet-matches/-/tweet-matches-1.0.1.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.13.3",
+      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+    },
+    "twit": {
+      "version": "1.1.20",
+      "from": "https://registry.npmjs.org/twit/-/twit-1.1.20.tgz",
+      "resolved": "https://registry.npmjs.org/twit/-/twit-1.1.20.tgz"
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    },
+    "type-is": {
+      "version": "1.6.13",
+      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+      "dependencies": {
+        "mime-types": {
+          "version": "2.1.12",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+        }
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "uglify-js": {
+      "version": "2.4.24",
+      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.1.34",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+    },
+    "umd": {
+      "version": "2.0.0",
+      "from": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz"
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "from": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "url": {
+      "version": "0.10.3",
+      "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
+    "useragent": {
+      "version": "2.1.9",
+      "from": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.2.4",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+        }
+      }
+    },
+    "utf-8-validate": {
+      "version": "1.2.1",
+      "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
+      "dependencies": {
+        "nan": {
+          "version": "2.4.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+        }
+      }
+    },
+    "utf8": {
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+    },
+    "v8flags": {
+      "version": "2.0.11",
+      "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+    },
+    "validator": {
+      "version": "1.5.1",
+      "from": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        }
+      }
+    },
+    "vinyl-source-stream": {
+      "version": "0.1.1",
+      "from": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-0.1.1.tgz",
+      "dependencies": {
+        "vinyl": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+        },
+        "through2": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.3.0.tgz"
+        },
         "readable-stream": {
           "version": "1.0.34",
           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -5332,827 +5611,479 @@
         }
       }
     },
-    "tildify": {
-      "version": "1.2.0",
-      "from": "tildify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
-    },
-    "time-stamp": {
-      "version": "1.0.1",
-      "from": "time-stamp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
-    },
-    "timekeeper": {
-      "version": "0.0.4",
-      "from": "timekeeper@0.0.4",
-      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-0.0.4.tgz"
-    },
-    "timers-browserify": {
-      "version": "1.0.3",
-      "from": "timers-browserify@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "from": "process@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
-        }
-      }
-    },
-    "timezone": {
-      "version": "0.0.32",
-      "from": "timezone@0.0.32",
-      "resolved": "https://registry.npmjs.org/timezone/-/timezone-0.0.32.tgz"
-    },
-    "tinycolor": {
-      "version": "0.0.1",
-      "from": "tinycolor@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-    },
-    "tmp": {
-      "version": "0.0.28",
-      "from": "tmp@0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "from": "to-array@0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
-    },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "from": "to-iso-string@0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
-    },
-    "tough-cookie": {
-      "version": "2.3.1",
-      "from": "tough-cookie@>=0.12.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-    },
-    "tty-browserify": {
-      "version": "0.0.0",
-      "from": "tty-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-    },
-    "tweet-matches": {
-      "version": "1.0.1",
-      "from": "tweet-matches@1.0.1",
-      "resolved": "https://registry.npmjs.org/tweet-matches/-/tweet-matches-1.0.1.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.0 <0.14.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-    },
-    "twit": {
-      "version": "1.1.20",
-      "from": "twit@>=1.1.12 <1.2.0",
-      "resolved": "https://registry.npmjs.org/twit/-/twit-1.1.20.tgz"
-    },
-    "type-detect": {
-      "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-    },
-    "type-is": {
-      "version": "1.6.13",
-      "from": "type-is@>=1.6.10 <1.7.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-      "dependencies": {
-        "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@>=2.1.11 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
-        }
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-    },
-    "uglify-js": {
-      "version": "2.4.24",
-      "from": "uglify-js@>=2.4.0 <2.5.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "from": "source-map@0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz"
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "from": "uid2@0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-    },
-    "ultron": {
-      "version": "1.0.2",
-      "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-    },
-    "umd": {
-      "version": "2.0.0",
-      "from": "umd@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz"
-    },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "from": "unc-path-regex@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "from": "underscore@>=1.6.0 <1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-    },
-    "unique-stream": {
-      "version": "1.0.0",
-      "from": "unique-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "from": "unpipe@1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-    },
-    "url": {
-      "version": "0.10.3",
-      "from": "url@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "from": "punycode@1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-        }
-      }
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-    },
-    "useragent": {
-      "version": "2.1.9",
-      "from": "useragent@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "from": "lru-cache@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
-        }
-      }
-    },
-    "utf-8-validate": {
-      "version": "1.2.1",
-      "from": "utf-8-validate@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
-      "dependencies": {
-        "nan": {
-          "version": "2.4.0",
-          "from": "nan@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
-        }
-      }
-    },
-    "utf8": {
-      "version": "2.1.0",
-      "from": "utf8@2.1.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
-    },
-    "util": {
-      "version": "0.10.3",
-      "from": "util@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        }
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-    },
-    "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-    },
-    "v8flags": {
-      "version": "2.0.11",
-      "from": "v8flags@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-    },
-    "validator": {
-      "version": "1.5.1",
-      "from": "validator@>=1.5.1 <1.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
-    },
-    "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "from": "vinyl@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
-    },
-    "vinyl-fs": {
-      "version": "0.3.14",
-      "from": "vinyl-fs@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "from": "strip-bom@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "from": "vinyl@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0-0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        }
-      }
-    },
-    "vinyl-source-stream": {
-      "version": "0.1.1",
-      "from": "vinyl-source-stream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-0.1.1.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.17 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "0.3.0",
-          "from": "through2@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.3.0.tgz"
-        },
-        "vinyl": {
-          "version": "0.2.3",
-          "from": "vinyl@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "from": "xtend@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
-        }
-      }
-    },
     "vm-browserify": {
       "version": "0.0.4",
-      "from": "vm-browserify@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "void-elements": {
       "version": "2.0.1",
-      "from": "void-elements@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
     "watchify": {
       "version": "3.2.1",
-      "from": "watchify@3.2.1",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.2.1.tgz",
       "dependencies": {
-        "JSONStream": {
-          "version": "1.2.1",
-          "from": "JSONStream@^1.0.3",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz"
-        },
-        "acorn": {
-          "version": "3.3.0",
-          "from": "acorn@^3.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-        },
-        "assert": {
-          "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
-        },
-        "browser-pack": {
-          "version": "5.0.1",
-          "from": "browser-pack@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
-          "dependencies": {
-            "through2": {
-              "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
-            }
-          }
-        },
-        "browser-resolve": {
-          "version": "1.11.2",
-          "from": "browser-resolve@>=1.7.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
-        },
         "browserify": {
           "version": "10.2.6",
-          "from": "browserify@>=10.0.0 <11.0.0",
+          "from": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
           "dependencies": {
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+            }
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        },
+        "JSONStream": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz"
+        },
+        "acorn": {
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        },
+        "assert": {
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
+        },
+        "combine-source-map": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz"
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.11.0",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
+        },
+        "detective": {
+          "version": "4.3.2",
+          "from": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
+        },
+        "inline-source-map": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+        },
+        "jsonparse": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+        },
+        "lexical-scope": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "parents": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
+        },
+        "path-platform": {
+          "version": "0.11.15",
+          "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+        },
+        "process": {
+          "version": "0.11.9",
+          "from": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
+        },
+        "umd": {
+          "version": "3.0.1",
+          "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+        },
+        "browser-pack": {
+          "version": "5.0.1",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "dependencies": {
+            "through2": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.6.0",
-          "from": "buffer@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
-        "combine-source-map": {
-          "version": "0.6.1",
-          "from": "combine-source-map@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz"
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
-        },
-        "convert-source-map": {
-          "version": "1.1.3",
-          "from": "convert-source-map@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
-        },
-        "crypto-browserify": {
-          "version": "3.11.0",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
-        },
-        "defined": {
-          "version": "1.0.0",
-          "from": "defined@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-        },
         "deps-sort": {
           "version": "1.3.9",
-          "from": "deps-sort@>=1.3.7 <2.0.0",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
             }
           }
         },
-        "detective": {
-          "version": "4.3.2",
-          "from": "detective@^4.0.0",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz"
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.0.5 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-        },
-        "http-browserify": {
-          "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
-        },
-        "inline-source-map": {
-          "version": "0.5.0",
-          "from": "inline-source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
-        },
         "insert-module-globals": {
           "version": "6.6.3",
-          "from": "insert-module-globals@>=6.4.1 <7.0.0",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
           "dependencies": {
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
             }
           }
         },
-        "jsonparse": {
-          "version": "1.2.0",
-          "from": "jsonparse@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-        },
-        "lexical-scope": {
-          "version": "1.2.0",
-          "from": "lexical-scope@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
         "module-deps": {
           "version": "3.9.1",
-          "from": "module-deps@>=3.7.11 <4.0.0",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "dependencies": {
             "through2": {
               "version": "1.1.1",
-              "from": "through2@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
             }
           }
-        },
-        "parents": {
-          "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
-        },
-        "path-platform": {
-          "version": "0.11.15",
-          "from": "path-platform@>=0.11.15 <0.12.0",
-          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
-        },
-        "process": {
-          "version": "0.11.9",
-          "from": "process@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "from": "punycode@>=1.3.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-        },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "subarg": {
-          "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            }
-          }
-        },
-        "umd": {
-          "version": "3.0.1",
-          "from": "umd@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "websocket-driver": {
       "version": "0.6.5",
-      "from": "websocket-driver@>=0.3.6",
+      "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
     },
     "websocket-extensions": {
       "version": "0.1.1",
-      "from": "websocket-extensions@>=0.1.1",
+      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
     "which": {
       "version": "1.2.11",
-      "from": "which@>=1.2.10 <2.0.0",
+      "from": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
+      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "winston": {
       "version": "0.8.3",
-      "from": "winston@>=0.8.3 <0.9.0",
+      "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
     },
     "winston-amazon-ses": {
       "version": "0.1.4",
-      "from": "winston-amazon-ses@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/winston-amazon-ses/-/winston-amazon-ses-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/winston-amazon-ses/-/winston-amazon-ses-0.1.4.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.4.2",
-          "from": "underscore@1.4.2",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.2.tgz"
         }
       }
     },
     "winston-slack-transport": {
       "version": "2.0.0",
-      "from": "winston-slack-transport@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/winston-slack-transport/-/winston-slack-transport-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/winston-slack-transport/-/winston-slack-transport-2.0.0.tgz",
       "dependencies": {
+        "request": {
+          "version": "2.79.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+        },
         "assert-plus": {
           "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "boom": {
           "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "2.1.2",
-          "from": "form-data@>=2.1.1 <2.2.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
         "mime-db": {
           "version": "1.25.0",
-          "from": "mime-db@>=1.25.0 <1.26.0",
+          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
         },
         "mime-types": {
           "version": "2.1.13",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.3.0",
-          "from": "qs@>=6.3.0 <6.4.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
-        },
-        "request": {
-          "version": "2.79.0",
-          "from": "request@>=2.67.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         },
         "uuid": {
           "version": "3.0.0",
-          "from": "uuid@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
         }
       }
     },
     "wordwrap": {
       "version": "0.0.3",
-      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "ws": {
       "version": "0.4.32",
-      "from": "ws@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
       "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
       "dependencies": {
         "commander": {
           "version": "2.1.0",
-          "from": "commander@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
         },
         "nan": {
           "version": "1.0.0",
-          "from": "nan@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
         }
       }
     },
     "xml2js": {
       "version": "0.4.15",
-      "from": "xml2js@0.4.15",
+      "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
       "dependencies": {
         "sax": {
           "version": "1.2.1",
-          "from": "sax@>=0.6.0",
+          "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
         }
       }
     },
     "xmlbuilder": {
       "version": "2.6.2",
-      "from": "xmlbuilder@2.6.2",
+      "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.5.0",
-          "from": "lodash@>=3.5.0 <3.6.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
         }
       }
     },
     "xmlhttprequest": {
       "version": "1.4.2",
-      "from": "xmlhttprequest@1.4.2",
+      "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
-      "from": "xmlhttprequest-ssl@1.5.1",
+      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xtend": {
       "version": "3.0.0",
-      "from": "xtend@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
     },
     "yargs": {
       "version": "3.5.4",
-      "from": "yargs@>=3.5.4 <3.6.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
     },
     "yauzl": {
       "version": "2.4.1",
-      "from": "yauzl@2.4.1",
+      "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
     },
     "yeast": {
       "version": "0.1.2",
-      "from": "yeast@0.1.2",
+      "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
     },
     "zeparser": {
       "version": "0.0.5",
-      "from": "zeparser@0.0.5",
+      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,28 +12,6 @@
       "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz"
     },
-    "accepts": {
-      "version": "1.1.4",
-      "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
-      "dependencies": {
-        "mime-types": {
-          "version": "2.0.14",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-        },
-        "negotiator": {
-          "version": "0.4.9",
-          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-        }
-      }
-    },
     "accessibility-developer-tools": {
       "version": "2.6.0",
       "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
@@ -58,11 +36,6 @@
       "version": "0.4.4",
       "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
-    },
-    "after": {
-      "version": "0.8.1",
-      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
     },
     "agent-base": {
       "version": "2.0.1",
@@ -315,11 +288,6 @@
       "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
-    "base64-arraybuffer": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-    },
     "base64-js": {
       "version": "0.0.8",
       "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
@@ -356,11 +324,6 @@
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-    },
-    "benchmark": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
@@ -665,12 +628,12 @@
       "dependencies": {
         "fsevents": {
           "version": "1.1.2",
-          "from": "fsevents@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
           "dependencies": {
             "nan": {
               "version": "2.7.0",
-              "from": "nan@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
             },
             "node-pre-gyp": {
@@ -683,15 +646,15 @@
               "from": "abbrev@1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
             },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "from": "ansi-regex@2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            },
             "ajv": {
               "version": "4.11.8",
               "from": "ajv@4.11.8",
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "ansi-regex@2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
             },
             "aproba": {
               "version": "1.1.1",
@@ -1078,10 +1041,20 @@
               "from": "request@2.81.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
             },
+            "rimraf": {
+              "version": "2.6.1",
+              "from": "rimraf@2.6.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+            },
             "safe-buffer": {
               "version": "5.0.1",
               "from": "safe-buffer@5.0.1",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+            },
+            "semver": {
+              "version": "5.3.0",
+              "from": "semver@5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
             },
             "set-blocking": {
               "version": "2.0.0",
@@ -1158,6 +1131,11 @@
               "from": "util-deprecate@1.0.2",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             },
+            "uuid": {
+              "version": "3.0.1",
+              "from": "uuid@3.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+            },
             "verror": {
               "version": "1.3.6",
               "from": "verror@1.3.6",
@@ -1172,21 +1150,6 @@
               "version": "1.0.2",
               "from": "wrappy@1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "from": "rimraf@2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-            },
-            "semver": {
-              "version": "5.3.0",
-              "from": "semver@5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "from": "uuid@3.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
             },
             "dashdash": {
               "version": "1.14.1",
@@ -1727,52 +1690,6 @@
         }
       }
     },
-    "engine.io": {
-      "version": "1.6.10",
-      "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ws": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "1.6.9",
-      "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
-      "dependencies": {
-        "ws": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "1.2.4",
-      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-      "dependencies": {
-        "has-binary": {
-          "version": "0.1.6",
-          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
-        }
-      }
-    },
     "ent": {
       "version": "2.2.0",
       "from": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -2061,18 +1978,6 @@
       "version": "2.2.3",
       "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-    },
-    "finalhandler": {
-      "version": "0.5.0",
-      "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        }
-      }
     },
     "find-index": {
       "version": "0.1.1",
@@ -3133,11 +3038,6 @@
       "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
-    "json3": {
-      "version": "3.2.6",
-      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-    },
     "jsonfile": {
       "version": "2.4.0",
       "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -4113,21 +4013,6 @@
       "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
-    "parsejson": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
-    },
-    "parseqs": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
-    },
-    "parseuri": {
-      "version": "0.0.4",
-      "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
-    },
     "parseurl": {
       "version": "1.3.1",
       "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
@@ -4240,15 +4125,15 @@
           "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
         },
-        "async": {
-          "version": "2.1.2",
-          "from": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
-        },
         "assert-plus": {
           "version": "0.2.0",
           "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+        },
+        "async": {
+          "version": "2.1.2",
+          "from": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
@@ -4670,7 +4555,7 @@
     },
     "rwlock": {
       "version": "5.0.0",
-      "from": "rwlock@latest",
+      "from": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz"
     },
     "samsam": {
@@ -4909,47 +4794,6 @@
         }
       }
     },
-    "socket.io-adapter": {
-      "version": "0.4.0",
-      "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "socket.io-parser": {
-          "version": "2.2.2",
-          "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "2.2.6",
-      "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "json3": {
-          "version": "3.3.2",
-          "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-        }
-      }
-    },
     "source-map": {
       "version": "0.1.43",
       "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
@@ -5170,15 +5014,15 @@
           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
         },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
         "async": {
           "version": "1.5.2",
           "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -5299,11 +5143,6 @@
       "version": "0.0.1",
       "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-    },
-    "tmp": {
-      "version": "0.0.28",
-      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
     },
     "to-array": {
       "version": "0.1.4",
@@ -5446,18 +5285,6 @@
       "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
-    "useragent": {
-      "version": "2.1.9",
-      "from": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
-        }
-      }
-    },
     "utf-8-validate": {
       "version": "1.2.1",
       "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
@@ -5469,11 +5296,6 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         }
       }
-    },
-    "utf8": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
     },
     "util": {
       "version": "0.10.3",
@@ -5491,11 +5313,6 @@
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-    },
-    "utils-merge": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "v8flags": {
       "version": "2.0.11",
@@ -5680,15 +5497,15 @@
           "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
         },
-        "combine-source-map": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz"
-        },
         "console-browserify": {
           "version": "1.1.0",
           "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+        },
+        "combine-source-map": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz"
         },
         "convert-source-map": {
           "version": "1.1.3",
@@ -6048,11 +5865,6 @@
       "version": "1.4.2",
       "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xtend": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "protractor-with-apis": "protractor test/end-to-end/with-apis/protractor.conf.js"
   },
   "dependencies": {
+    "JSONStream": "~0.7.4",
     "angular-cookies": "~1.2.29",
     "angular-translate": "^2.11.1",
     "angular-translate-handler-log": "^2.11.1",
@@ -50,7 +51,6 @@
     "gulp-rename": "^1.2.2",
     "interval-to-human": "~0.1.1",
     "jsmin": "~1.0.1",
-    "JSONStream": "~0.7.4",
     "locale": "0.0.20",
     "lodash": "^4.15.0",
     "migrate": "^0.2.3",
@@ -70,6 +70,7 @@
     "passport.socketio": "~3.0.1",
     "request": "~2.34.0",
     "resanitize": "~0.3.0",
+    "rwlock": "^5.0.0",
     "single-line-log": "~0.4.1",
     "socket.io": "~0.9.16",
     "strformat": "0.0.3",

--- a/test/backend/models.batch.test.js
+++ b/test/backend/models.batch.test.js
@@ -9,7 +9,7 @@ var ReportQuery = require('../../models/query/report-query');
 var async = require('async');
 var _ = require('lodash');
 
-var user, t;
+var user, user2, t;
 
 // helpers
 function timeAgo(milliseconds) {
@@ -22,6 +22,30 @@ function loadUser(done) {
     user = u;
     done(err);
   });
+}
+
+function createUser2(done) {
+  User.create({ provider: 'test', email: 'batch@example.com', username: 'batchTest', password: 'batchbatch' },
+              function(err, u) {
+                user2 = u;
+                done(err);
+              });
+}
+
+function removeUser2(done) {
+  User.remove({ username: 'batchTest' }, function(err) {
+    done(err);
+  });
+}
+
+function createReports(done) {
+  var reports = [];
+  var totalReports = 50;
+
+  for (var i = 0; i < totalReports; i++) {
+    reports.push({ storedAt: new Date(t.getTime()), content: i });
+  }
+  Report.create(reports, done);
 }
 
 function createReport(done) {
@@ -40,11 +64,13 @@ function createReport(done) {
 
 describe('Report', function() {
   beforeEach(function(done) {
-    async.series([loadUser, createReport], done);
+    async.series([loadUser, createReport, createUser2], done);
   });
 
   afterEach(function(done) {
-    Report.remove({}, done);
+    async.series([removeUser2, function(done) {
+      Report.remove({}, done);
+    }], done);
   });
 
   it('should lock a batch', function(done) {
@@ -106,6 +132,23 @@ describe('Report', function() {
     batch.cancel(user._id, function(err, num) {
       expect(num).to.eq(1);
       done(err);
+    });
+  });
+
+  it('should not give same reports to different users', function(done) {
+    var batches = [];
+    createReports(function() {
+      async.filter([user._id, user2._id], function(user, cb) {
+        batch.checkout(user, {}, function(err, reports) {
+          batches.push(reports);
+          cb(err);
+        });
+      }, function() {
+        expect(batches[0].length).to.eq(10);
+        expect(batches[1].length).to.eq(10);
+        expect(_.intersection(batches[0], batches[1]).length).to.eq(0);
+        done();
+      });
     });
   });
 

--- a/test/backend/models.batch.test.js
+++ b/test/backend/models.batch.test.js
@@ -138,9 +138,7 @@ describe('Report', function() {
   it('should not give same reports to different users', function(done) {
     createReports(function() {
       async.map([user._id, user2._id], function(user, cb) {
-        batch.checkout(user, {}, function(err, reports) {
-          cb(err, reports);
-        });
+        batch.checkout(user, {}, cb);
       }, function(err, batches) {
         if (err) done(err);
         expect(batches[0].length).to.eq(10);

--- a/test/backend/models.batch.test.js
+++ b/test/backend/models.batch.test.js
@@ -136,14 +136,13 @@ describe('Report', function() {
   });
 
   it('should not give same reports to different users', function(done) {
-    var batches = [];
     createReports(function() {
-      async.filter([user._id, user2._id], function(user, cb) {
+      async.map([user._id, user2._id], function(user, cb) {
         batch.checkout(user, {}, function(err, reports) {
-          batches.push(reports);
-          cb(err);
+          cb(err, reports);
         });
-      }, function() {
+      }, function(err, batches) {
+        if (err) done(err);
         expect(batches[0].length).to.eq(10);
         expect(batches[1].length).to.eq(10);
         expect(_.intersection(batches[0], batches[1]).length).to.eq(0);


### PR DESCRIPTION
MongoDB does not have support for atomic updates of batches. While we move to
some other DB, a locking mechanism is put in place to make sure that reports are
only checked out by one user at a time.