### PR TITLE
5438: Angular task now produces uglified app.min.js. Use debugAngular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,14 @@ lib-cov
 *.gz
 *.swp
 *.swo
+*.map
 
 pids
 logs
 results
 tmp
 
-npm-debug.log
+npm-debug*
 node_modules
 fiddle
 .idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,10 @@ var jshint = require('gulp-jshint');
 var mocha = require('gulp-mocha');
 var rename = require('gulp-rename');
 var browserify = require('gulp-browserify');
+var uglify = require('gulp-uglify');
+var buffer = require('vinyl-buffer');
+var ngAnnotate = require('gulp-ng-annotate');
+var sourcemaps = require('gulp-sourcemaps');
 var plumber = require('gulp-plumber');
 var livereload = require('gulp-livereload');
 var jsoncombine = require('gulp-jsoncombine');
@@ -44,13 +48,26 @@ gulp.task('lint', function() {
 pipes.buildAngular = function() {
   return gulp.src('public/angular/js/app.js')
     .pipe(plumber())
+    .pipe(sourcemaps.init())
+    .pipe(browserify())
+    .pipe(ngAnnotate())
+    .pipe(buffer())
+    .pipe(uglify())
+    .pipe(rename('app.min.js'))
+    .pipe(sourcemaps.write('./'))
+    .pipe(gulp.dest('public/angular/js'));
+};
+
+pipes.debugAngular = function() {
+  return gulp.src('public/angular/js/app.js')
+    .pipe(plumber())
     .pipe(browserify())
     .pipe(rename('app.min.js'))
     .pipe(gulp.dest('public/angular/js'));
 };
 
 gulp.task('watchAngular', function() {
-  pipes.buildAngular()
+  pipes.debugAngular()
     .pipe(livereload());
 });
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
     "dateformat": "^1.0.11",
     "deep-keys": "^0.3.0",
     "gulp-jsoncombine": "^1.0.3",
+    "gulp-ng-annotate": "^2.0.0",
+    "gulp-sourcemaps": "^2.6.1",
+    "gulp-uglify": "^3.0.0",
     "karma": "^1.1.2",
     "karma-browserify": "^4.0.0",
     "karma-chai-plugins": "^0.7.0",
@@ -104,7 +107,8 @@
     "protractor": "^2.5.1",
     "socket.io": "^0.9.17",
     "socket.io-client": "^0.9.16",
-    "supertest": "^2.0.0"
+    "supertest": "^2.0.0",
+    "vinyl-buffer": "^1.0.0"
   },
   "subdomain": "aggie",
   "engines": {


### PR DESCRIPTION
Use debugAngular or  angular.watch task for better debugging of angular app during development.
Angular task will now produce the production ready app, 1.3Mb smaller than before. It also produces app.min.js.map in case we need to debug errors in production.