### PR TITLE
Get travis to use mongodb3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
-services: mongodb
+addons:
+  sources:
+    - mongodb-3.2-trusty
+  packages:
+    - mongodb-org
 
 before_script:
+  - sleep 15
+  - mongod --version
   - cp config/secrets.json.example config/secrets.json
   - openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 addons:
-  sources:
+  apt:
+    sources:
     - mongodb-3.2-trusty
-  packages:
+    packages:
     - mongodb-org
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: node_js
-addons:
-  apt:
-    sources:
-    - mongodb-3.2-trusty
-    packages:
-    - mongodb-org-server=3.2.16
-    - mongodb-org-shell=3.2.16
-before_install:
-  - sleep 15
-  - mongo --eval "printjson(db.serverStatus())"
+group: deprecated-2017Q4
+services: mongodb
 before_script:
   - cp config/secrets.json.example config/secrets.json
   - openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ addons:
     sources:
     - mongodb-3.2-trusty
     packages:
-    - systemd
     - mongodb-org-server=3.2.16
     - mongodb-org-shell=3.2.16
 before_install:
-  - apt policy systemd
-  - sudo systemctl start mongodb
+  - mongod -dbpath=/var/lib/mongodb &
 before_script:
   - cp config/secrets.json.example config/secrets.json
   - openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ addons:
     - mongodb-org-server=3.2.16
     - mongodb-org-shell=3.2.16
 before_install:
-  - mongod -dbpath=/var/lib/mongodb &
+  - sleep 15
+  - mongo --eval "printjson(db.serverStatus())"
 before_script:
   - cp config/secrets.json.example config/secrets.json
   - openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ addons:
     sources:
     - mongodb-3.2-trusty
     packages:
-    - mongodb-org
-
+    - systemd
+    - mongodb-org-server=3.2.16
+    - mongodb-org-shell=3.2.16
+before_install:
+  - apt policy systemd
+  - sudo systemctl start mongodb
 before_script:
-  - sleep 15
-  - mongod --version
   - cp config/secrets.json.example config/secrets.json
   - openssl req -x509 -newkey rsa:2048 -keyout config/key.pem -out config/cert.pem -days 365 -nodes -subj "/O=Aggie"


### PR DESCRIPTION
Latest version is using 3.4 which breaks the version of our mongodb driver