### PR TITLE
Add "Remove from Incident" button to the Incident page

### DIFF
--- a/lib/api/v1/report-controller.js
+++ b/lib/api/v1/report-controller.js
@@ -175,6 +175,24 @@ module.exports = function(app, user) {
     });
   });
 
+  // Unlink selected reports from an incident
+  app.patch('/api/v1/report/_unlink', user.can('edit data'), function(req, res) {
+    if (!req.body.ids || !req.body.ids.length) return res.send(200);
+    Report.find({ _id: { $in: req.body.ids } }, function(err, reports) {
+      if (err) return res.send(err.status, err.message);
+      if (reports.length === 0) return res.send(200);
+      var remaining = reports.length;
+      reports.forEach(function(report) {
+        report._incident = null;
+        report.save(function(err) {
+          if (err) return res.send(err.status, err.message);
+          writelog.writeReport(req, report, 'removeFromIncident');
+          if (--remaining === 0) return res.send(200);
+        });
+      });
+    });
+  });
+
   return app;
 };
 

--- a/models/incident.js
+++ b/models/incident.js
@@ -74,21 +74,25 @@ var Incident = mongoose.model('Incident', schema);
 
 Report.schema.on('change:incident', function(prevIncident, newIncident) {
   if (prevIncident !== newIncident) {
-    // Callbacks added to execute query immediately
-    Incident.findByIdAndUpdate(prevIncident, { $inc: { totalReports: -1 } }, function(err) {
+    if (prevIncident) {
+      // Callbacks added to execute query immediately
+      Incident.findByIdAndUpdate(prevIncident, { $inc: { totalReports: -1 } }, function(err) {
+        if (err) {
+          logger.error(err);
+        }
+        schema.emit('incident:update');
+      });
+    }
+  }
+
+  if (newIncident) {
+    Incident.findByIdAndUpdate(newIncident, { $inc: { totalReports: 1 } }, function(err) {
       if (err) {
         logger.error(err);
       }
       schema.emit('incident:update');
     });
   }
-
-  Incident.findByIdAndUpdate(newIncident, { $inc: { totalReports: 1 } }, function(err) {
-    if (err) {
-      logger.error(err);
-    }
-    schema.emit('incident:update');
-  });
 });
 
 // Query incidents based on passed query data

--- a/public/angular/js/controllers/incidents/show.js
+++ b/public/angular/js/controllers/incidents/show.js
@@ -127,12 +127,37 @@ angular.module('Aggie')
       });
     };
 
-    $scope.unlinkReport = function(report) {
-      report._incident = null;
-      $scope.saveReport(report);
-      flash.setNotice('notice.report.unlinked');
-      $state.go('incident', { id: $scope.incident._id }, { reload: true });
+    $scope.someSelected = function() {
+      return $scope.reports.some(function(report) {
+        return report.selected;
+      });
     };
+
+    $scope.filterSelected = function(items) {
+      return items.reduce(function(memo, item) {
+        if (item.selected) memo.push(item);
+        return memo;
+      }, []);
+    };
+
+    var getIds = function(items) {
+      return items.map(function(item) {
+        return item._id;
+      });
+    };
+
+    $scope.unlinkSelected = function() {
+      var items = $scope.filterSelected($scope.reports);
+      if (!items.length) return;
+
+      var ids = getIds(items);
+      Report.unlinkFromIncident({ ids: ids }, function() {
+        flash.setNotice('notice.report.unlinkMultiple.success');
+        $state.go('incident', { id: $scope.incident._id }, { reload: true });
+      }, function() {
+        flash.setAlertNow('notice.report.unlinkMultiple.error');
+      });
+    }
 
     $scope.viewProfile = function(user) {
       $state.go('profile', { userName: user.username });

--- a/public/angular/js/services/report.js
+++ b/public/angular/js/services/report.js
@@ -9,6 +9,7 @@ angular.module('Aggie')
     'update': { method: 'PUT' },
     'toggleRead': { method: 'PATCH', url: '/api/v1/report/_read', isArray: false },
     'toggleFlagged': { method: 'PATCH', url: '/api/v1/report/_flag', isArray: false },
-    'linkToIncident': { method: 'PATCH', url: '/api/v1/report/_link', isArray: false }
+    'linkToIncident': { method: 'PATCH', url: '/api/v1/report/_link', isArray: false },
+    'unlinkFromIncident': { method: 'PATCH', url: '/api/v1/report/_unlink', isArray: false }
   });
 });

--- a/public/angular/templates/incidents/show.html
+++ b/public/angular/templates/incidents/show.html
@@ -55,18 +55,26 @@
 
 <div ng-show="pagination.total > 0">
   <div class="table-actions">
-    <div class="pull-right padding-top-bottom pagination">
-      <ul class="pager">
-        <li class="pager-label">
-          {{ pagination.start }} - {{ pagination.end }} {{'of' | translate}} {{ pagination.total | maxCount:pagination.visibleTotal }}
-        </li>
-        <li>
-          <button ng-class="{disabled: isFirstPage() }" ui-sref="incident({ id: incident._id, page: pagination.page - 1 })" class="btn btn-info">&lsaquo;</button>
-        </li>
-        <li>
-          <button ng-class="{disabled: isLastPage() }" ui-sref="incident({ id: incident._id, page: pagination.page + 1 })" class="btn btn-info">&rsaquo;</button>
-        </li>
-      </ul>
+    <div class="button-row margin-bottom-lg">
+      <div class="pull-left margin-right padding-top-bottom checkbox-btn bg-gray">
+        <input ng-select-all items="reports" type="checkbox" />
+      </div>
+      <div class="pull-left padding-top-bottom">
+        <a ng-class="{highlight: someSelected()}" class="btn btn-default" ng-click="unlinkSelected()" translate>Remove from Incident</a>
+      </div>
+      <div class="pull-right padding-top-bottom pagination">
+        <ul class="pager">
+          <li class="pager-label">
+            {{ pagination.start }} - {{ pagination.end }} {{'of' | translate}} {{ pagination.total | maxCount:pagination.visibleTotal }}
+          </li>
+          <li>
+            <button ng-class="{disabled: isFirstPage() }" ui-sref="incident({ id: incident._id, page: pagination.page - 1 })" class="btn btn-info">&lsaquo;</button>
+          </li>
+          <li>
+            <button ng-class="{disabled: isLastPage() }" ui-sref="incident({ id: incident._id, page: pagination.page + 1 })" class="btn btn-info">&rsaquo;</button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div ng-include="'/templates/reports/table.html'"></div>

--- a/public/angular/translations/locale-en.json
+++ b/public/angular/translations/locale-en.json
@@ -5,7 +5,10 @@
   "password_too_short": "That password was too short. Please use a longer one.",
   "notice": {
     "report": {
-      "unlinked": "Report has been successfully unlinked"
+      "unlinkMultiple": {
+        "success": "Reports have been successfully unlinked",
+        "error": "Reports failed to be unlinked"
+      }
     }
   },
   "relevant": "Relevant",
@@ -318,6 +321,7 @@
   "Linked Incident": "Linked Incident",
   "Date/Time": "Date/Time",
   "Add to Incident": "Add to Incident",
+  "Remove from Incident": "Remove from Incident",
   "Grab Batch": "Grab Batch",
 "There are currently no trends. Click 'Create Trend' to make one.": "There are currently no trends. Click 'Create Trend' to make one.",
   "Data updated every 10 seconds. Data grouped into 5 minute intervals. Click data points (circles) to view matching reports.": "Data updated every 10 seconds. Data grouped into 5 minute intervals. Click data points (circles) to view matching reports.",

--- a/public/angular/translations/locale-en.json
+++ b/public/angular/translations/locale-en.json
@@ -7,7 +7,7 @@
     "report": {
       "unlinkMultiple": {
         "success": "Reports have been successfully unlinked",
-        "error": "Reports failed to be unlinked"
+        "error": "An error occurred while unlinking the Reports"
       }
     }
   },

--- a/public/angular/translations/locale-es.json
+++ b/public/angular/translations/locale-es.json
@@ -5,7 +5,10 @@
   "password_too_short": "La contraseña es muy corta. Use una más larga.",
   "notice": {
     "report": {
-      "unlinked": "El informe ha sido desconectado del incidente"
+      "unlinkMultiple": {
+        "success": "El informe ha sido desconectado del incidente",
+        "error": "TODO TODO TODO"
+      }
     }
   },
   "relevant": "Relevante",
@@ -317,6 +320,7 @@
   "Linked Incident": "Incidente conectado",
   "Date/Time": "Fecha/Hora",
   "Add to Incident": "Añadir a incidente",
+  "Remove from Incident": "Eliminar del incidente",
   "Grab Batch": "Coger lote",
 "There are currently no trends. Click 'Create Trend' to make one.": "No hay tendencias de momento. Haga clic en 'Crear tendencia' parar crear una.",
   "Data updated every 10 seconds. Data grouped into 5 minute intervals. Click data points (circles) to view matching reports.": "Los datos se actualizan cada 10 segundos. Datos agrupados en intervalos de 5 minutos. Haga click en los los círculos para ver los informes de ese momento,",

--- a/public/angular/translations/locale-es.json
+++ b/public/angular/translations/locale-es.json
@@ -7,7 +7,7 @@
     "report": {
       "unlinkMultiple": {
         "success": "El informe ha sido desconectado del incidente",
-        "error": "TODO TODO TODO"
+        "error": "Se produjo un error al desvincular los informes."
       }
     }
   },


### PR DESCRIPTION
Resolves #313 

This PR primarily adds the "Remove From Incident" button to the Incident page for removing multiple Reports from an Incident at a time:

**Before**
![Screenshot from 2020-06-10 14-13-39](https://user-images.githubusercontent.com/34974152/84320089-17defb00-ab3f-11ea-81f7-f095440ad9f3.png)
**After**
![Screenshot from 2020-06-10 17-08-29](https://user-images.githubusercontent.com/34974152/84318867-19a7bf00-ab3d-11ea-99f5-ce91f5a0feb5.png)

This PR also makes several other secondary changes:

https://github.com/TID-Lab/aggie/commit/e2769391ef41214453ecd90c5b76520b91e76a61
- Fixes a bug where Aggie tries to update the Report count of nonexistent Incidents.

https://github.com/TID-Lab/aggie/commit/9a164138fade49638c821c7fc5ac745817a7964f
- adds a new API endpoint `v1/report/_unlink` for unlinking multiple Reports from an Incident at a time
- adds a checkbox to the Reports table on the Incidents "show" page that selects or deselects every Report in the table
- makes the blue pagination buttons on the top-right of the Reports table wider

Two tasks remain before this PR can be merged:
 - [x] An error alert for when unlinking Reports fails [needs a Spanish translation](https://github.com/TID-Lab/aggie/commit/9a164138fade49638c821c7fc5ac745817a7964f#diff-4c39c6996d00afaeecf8b86e1d362bbaR10)
 - [x] Write backend tests
