### PR TITLE
Instruct admins to configure Aggie email settings on email failure

### DIFF
--- a/lib/api/v1/user-controller.js
+++ b/lib/api/v1/user-controller.js
@@ -64,7 +64,7 @@ module.exports = function(app, user) {
       else {
         // Send password reset email
         sendEmail(user, req, function(err) {
-          if (err) res.send(err.status, err.message);
+          if (err) res.send(502, err.message); // send status code "Bad Gateway" to indicate email failure
           else res.send(200, user);
         });
       }

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -108,10 +108,9 @@ Mailer.prototype.sendFromTemplate = function(options, callback) {
                function mailTemplate(err, template) {
                  if (err) return callback(err);
                  var subject = template.subject;
-                 if (subject) subject = _.template(subject, options);
+                 if (subject) subject = _.template(subject)(options);
                  var body = template.body;
-                 if (body) body = _.template(body, options);
-
+                 if (body) body = _.template(body)(options);
                  that.send(subject, body, to, from, callback);
                });
 };

--- a/public/angular/js/controllers/users/form_modal.js
+++ b/public/angular/js/controllers/users/form_modal.js
@@ -78,15 +78,19 @@ angular.module('Aggie')
     };
 
     var handleError = function(response) {
-      $translate(response.data).then(function(error) {
-        $scope.message = error;
-      }).catch(function() {
-        if ($scope.user._id) {
-          $scope.message = 'user.update.error';
-        } else {
-          $scope.message = 'user.create.error';
-        }
-      });
+      if (response.status == 502) {
+        $scope.message = 'user.create.emailNotConfigured';
+      } else {
+        $translate(response.data).then(function(error) {
+          $scope.message = error;
+        }).catch(function() {
+          if ($scope.user._id) {
+            $scope.message = 'user.update.error';
+          } else {
+            $scope.message = 'user.create.error';
+          }
+        });
+      }
     };
 
     $scope.save = function(form) {

--- a/public/angular/translations/locale-en.json
+++ b/public/angular/translations/locale-en.json
@@ -130,7 +130,8 @@
   "user": {
     "create": {
       "success": "User was successfully created and an email has been sent to them with password instructions.",
-      "error": "User failed to be created. Please contact support."
+      "error": "User failed to be created. Please contact support.",
+      "emailNotConfigured": "Email settings not configured. Go to Settings > Settings > Email"
     },
     "update": {
       "success": "User was successfully updated.",

--- a/public/angular/translations/locale-es.json
+++ b/public/angular/translations/locale-es.json
@@ -130,7 +130,8 @@
   "user": {
     "create": {
       "success": "El usuario ha sido creado y se le ha enviado un email con instrucciones para iniciar la sessión.",
-      "error": "No ha sido posible crear el usuario. Por favor, contacte con el équipo técnico."
+      "error": "No ha sido posible crear el usuario. Por favor, contacte con el équipo técnico.",
+      "emailNotConfigured": "La configuración del correo electrónico no está configurada. Vaya a Configuración> Configuración> Correo electrónico"
     },
     "update": {
       "success": "Se ha actualizado la información del usuario.",


### PR DESCRIPTION
Resolves #308

This PR adds a new error message for when a user account is created, but their password reset email fails to send. The message directs the admin to visit the Email section of the Settings page:

![Screenshot (181)](https://user-images.githubusercontent.com/34974152/84406738-f2ea9680-abd7-11ea-9b74-2d1896cbd555.png)

This PR also makes secondary changes:
https://github.com/TID-Lab/aggie/commit/3aaf0dd0ef51359e0cebd5eae5098f32b54c9140
- Fix use of the Underscore `template` function so that data is correctly passed in [per the changes made in v1.7.0](https://underscorejs.org/#changelog)






