### PR TITLE
Fix broken close button for confirmation modal

### DIFF
--- a/public/angular/templates/confirm_modal.html
+++ b/public/angular/templates/confirm_modal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <button type="button" class="close" ng-click="close()" aria-hidden="true">×</button>
+  <button type="button" class="close" ng-click="cancel()" aria-hidden="true">×</button>
   <h4 class="modal-title" translate>Confirm</h4>
 </div>
 <div class="modal-body" translate>{{message}}</div>


### PR DESCRIPTION
Resolves #302 

This PR fixes the close button for the confirmation modal so that it functions the same as the "Cancel" button.

Remaining tasks before this PR can be merged:
- [ ] Write frontend & end-to-end tests (?)