### PR TITLE
Disable SES & Slack transports by default with "disabled" field #340

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,17 @@ Aggie uses Google Places for guessing locations in the application. To make it w
 
 ### Logging
 
-Set various logging options in `logger` section:
+Set various logging options in `logger` section.
 
-- `console` section is for console logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `file` section is for file logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `SES` section is for email notifications.
   - Set appropriate AWS key and secret values.
   - Set `to` and `from` email ids. Make sure `from` has been authorised in your Amazon SES configuration.
+- `Slack` section is for Slack messages.
+  - Set the webhook URL to send logs to a specific Slack channel
 - **DO NOT** set `level` to *debug*. Recommended value is *error*.
+
+Only the `file` transport is enabled by default. Transports can be disabled by adding the `"disabled": true` field to their section in the `config/secrets.json` file.
 
 ## Using the Application
 

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -46,14 +46,16 @@
       "to": "Aggie <aggie-admin@example.com>",
       "from": "Aggie <aggie@example.com>",
       "level": "error",
-      "silent": false
+      "silent": false,
+      "disabled": true
     },
     "Slack": {
       "webhookUrl": "https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ",
       "channel": "#aggie-deployments",
       "username": "Aggie@ServerName",
       "level": "error",
-      "handleExceptions": true
+      "handleExceptions": true,
+      "disabled": true
     },
     "file": {
       "level": "debug",
@@ -64,7 +66,7 @@
       "json": false,
       "prettyPrint": true,
       "filename": "logs/master.log",
-      "timestamp": true
+      "timestamp": true,
     },
     "api": {
       "log_requests": true,

--- a/lib/master-logger.js
+++ b/lib/master-logger.js
@@ -13,25 +13,26 @@ var loggerTimestamp = function() {
   return moment.utc().format('ddd, D MMM YYYY HH:mm:ss z');
 };
 
+// configure Winston transports
+function _configureTransports(name) {
+  var logger = config.logger;
+  if (logger.file.timestamp) logger.file.timestamp = loggerTimestamp;
+  logger.file.filename = logger[name].filename;
+
+  return [
+    !logger.SES.disabled ? null : new SESTransport(logger.SES),
+    !logger.Slack.disabled ? null : new SlackTransport(logger.Slack),
+    !logger.file.disabled ? null : winston.transports.File(logger.file)
+  ].filter(Boolean);
+}
+
 // configure specified logger
 function _configureLogger(name) {
-  if (config.logger.file.timestamp) config.logger.file.timestamp = loggerTimestamp;
-  config.logger.file.filename = config.logger[name].filename;
-
-  // Disable Slack transport if it hasn't been changed from the default.
-  const disableSlack = /XXXXX/.test(config.logger.Slack.webhookUrl);
-
-  var logger = winston.createLogger({
+  return winston.createLogger({
     levels: winston.config.npm.levels,
-    transports: [
-      new SESTransport(config.logger.SES),
-      disableSlack ? null : new SlackTransport(config.logger.Slack),
-      new winston.transports.File(config.logger.file)
-    ].filter(Boolean),
+    transports: _configureTransports(name),
     exitOnError: false
-  })
-
-  return logger;
+  });
 }
 
 // hash of various loggers, one for each process


### PR DESCRIPTION
Resolves #326 

- Introduces a `disabled` field for all transports
- Disables **SES** as well as Slack transport by default
- Updates README instructions for transport configuration