### PR TITLE
Disable SES & Slack transports by default with "disabled" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Aggie uses Google Places for guessing locations in the application. To make it w
 
 Set various logging options in `logger` section.
 
+- `console` section is for console logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `file` section is for file logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `SES` section is for email notifications.
   - Set appropriate AWS key and secret values.
@@ -278,7 +279,7 @@ Set various logging options in `logger` section.
   - Set the webhook URL to send logs to a specific Slack channel
 - **DO NOT** set `level` to *debug*. Recommended value is *error*.
 
-Only the `file` transport is enabled by default. Transports can be disabled by adding the `"disabled": true` field to their section in the `config/secrets.json` file.
+Only the `console` and `file` transports are enabled by default. Transports can be disabled using the `"disabled"` field included in each section in the `config/secrets.json` file.
 
 ## Using the Application
 

--- a/README.md
+++ b/README.md
@@ -265,16 +265,20 @@ Aggie uses Google Places for guessing locations in the application. To make it w
 1. Set `fetching` value to enable/disable fetching for all sources at global level.
   - This is also changed during runtime based on user choice.
 
+
 ### Logging
 
-Set various logging options in `logger` section:
+Set various logging options in `logger` section.
 
-- `console` section is for console logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `file` section is for file logging. For various options, see [winston](see https://github.com/winstonjs/winston#transports)
 - `SES` section is for email notifications.
   - Set appropriate AWS key and secret values.
   - Set `to` and `from` email ids. Make sure `from` has been authorised in your Amazon SES configuration.
+- `Slack` section is for Slack messages.
+  - Set the webhook URL to send logs to a specific Slack channel
 - **DO NOT** set `level` to *debug*. Recommended value is *error*.
+
+Only the `file` transport is enabled by default. Transports can be disabled by adding the `"disabled": true` field to their section in the `config/secrets.json` file.
 
 ## Using the Application
 

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -46,14 +46,16 @@
       "to": "Aggie <aggie-admin@example.com>",
       "from": "Aggie <aggie@example.com>",
       "level": "error",
-      "silent": false
+      "silent": false,
+      "disabled": true,
     },
     "Slack": {
       "webhookUrl": "https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ",
       "channel": "#aggie-deployments",
       "username": "Aggie@ServerName",
       "level": "error",
-      "handleExceptions": true
+      "handleExceptions": true,
+      "disabled": true,
     },
     "file": {
       "level": "debug",

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -47,7 +47,7 @@
       "to": "Aggie <aggie-admin@example.com>",
       "from": "Aggie <aggie@example.com>",
       "level": "error",
-      "silent": false,
+      "silent": false
     },
     "Slack": {
       "disabled": true,
@@ -55,11 +55,11 @@
       "channel": "#aggie-deployments",
       "username": "Aggie@ServerName",
       "level": "error",
-      "handleExceptions": true,
+      "handleExceptions": true
     },
     "file": {
+      "disabled": false,
       "level": "debug",
-      "silent": false,
       "colorize": true,
       "maxsize": 5242880,
       "maxFiles": 10,
@@ -67,6 +67,10 @@
       "prettyPrint": true,
       "filename": "logs/master.log",
       "timestamp": true
+    },
+    "console": {
+      "disabled": false,
+      "level": "debug"
     },
     "api": {
       "log_requests": true,

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -40,6 +40,7 @@
   },
   "logger": {
     "SES": {
+      "disabled": true,
       "accessKeyId": "AWSAccessKey",
       "secretAccessKey": "AWS/Secret/Key",
       "region": "us-east-1",
@@ -47,15 +48,14 @@
       "from": "Aggie <aggie@example.com>",
       "level": "error",
       "silent": false,
-      "disabled": true,
     },
     "Slack": {
+      "disabled": true,
       "webhookUrl": "https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ",
       "channel": "#aggie-deployments",
       "username": "Aggie@ServerName",
       "level": "error",
       "handleExceptions": true,
-      "disabled": true,
     },
     "file": {
       "level": "debug",

--- a/lib/master-logger.js
+++ b/lib/master-logger.js
@@ -13,25 +13,26 @@ var loggerTimestamp = function() {
   return moment.utc().format('ddd, D MMM YYYY HH:mm:ss z');
 };
 
+// configure Winston transports
+function _configureTransports(name) {
+  var logger = config.logger;
+  if (logger.file.timestamp) logger.file.timestamp = loggerTimestamp;
+  logger.file.filename = logger[name].filename;
+
+  return [
+    !logger.SES.disabled ? null : new SESTransport(logger.SES),
+    !logger.Slack.disabled ? null : new SlackTransport(logger.Slack),
+    !logger.file.disabled ? null : new winston.transports.File(logger.file)
+  ].filter(Boolean);
+}
+
 // configure specified logger
 function _configureLogger(name) {
-  if (config.logger.file.timestamp) config.logger.file.timestamp = loggerTimestamp;
-  config.logger.file.filename = config.logger[name].filename;
-
-  // Disable Slack transport if it hasn't been changed from the default.
-  const disableSlack = /XXXXX/.test(config.logger.Slack.webhookUrl);
-
-  var logger = winston.createLogger({
+  return winston.createLogger({
     levels: winston.config.npm.levels,
-    transports: [
-      new SESTransport(config.logger.SES),
-      disableSlack ? null : new SlackTransport(config.logger.Slack),
-      new winston.transports.File(config.logger.file)
-    ].filter(Boolean),
+    transports: _configureTransports(name),
     exitOnError: false
-  })
-
-  return logger;
+  });
 }
 
 // hash of various loggers, one for each process

--- a/lib/master-logger.js
+++ b/lib/master-logger.js
@@ -20,9 +20,10 @@ function _configureTransports(name) {
   logger.file.filename = logger[name].filename;
 
   return [
-    !logger.SES.disabled ? null : new SESTransport(logger.SES),
-    !logger.Slack.disabled ? null : new SlackTransport(logger.Slack),
-    !logger.file.disabled ? null : new winston.transports.File(logger.file)
+    logger.SES.disabled ? null : new SESTransport(logger.SES),
+    logger.Slack.disabled ? null : new SlackTransport(logger.Slack),
+    logger.file.disabled ? null : new winston.transports.File(logger.file),
+    logger.console.disabled ? null : new winston.transports.Console(logger.console),
   ].filter(Boolean);
 }
 


### PR DESCRIPTION
Resolves #326 

- Introduces a `disabled` field for all transports
- Disables **SES** as well as Slack transport by default
- Updates README instructions for transport configuration