### PR TITLE
fix: Make save() async to fix ParallelSaveError

### DIFF
--- a/lib/fetching/bots/pull-bot.js
+++ b/lib/fetching/bots/pull-bot.js
@@ -32,7 +32,7 @@ PullBot.prototype.stop = function() {
 PullBot.prototype.poll = function() {
   if (!this.enabled) return;
   var self = this;
-  this.fetch(function(err, lastReportDate, lastReportDateSavedSearch) {
+  this.fetch(async function(err, lastReportDate, lastReportDateSavedSearch) {
     if (err) {
       logger.warning(err);
     }
@@ -42,11 +42,11 @@ PullBot.prototype.poll = function() {
     // If fetch returned a lastReportDate, store it.
     if (lastReportDate && lastReportDate != -Infinity && self.source.lastReportDate !== lastReportDate) {
       self.source.lastReportDate = lastReportDate;
-      self.source.save();
+      await self.source.save();
     }
     if (lastReportDateSavedSearch && lastReportDateSavedSearch != -Infinity && self.source.lastReportDateSavedSearch !== lastReportDateSavedSearch) {
       self.source.lastReportDateSavedSearch = lastReportDateSavedSearch;
-      self.source.save();
+      await self.source.save();
     }
   });
 };


### PR DESCRIPTION
Error when fetching well-formatted NEMO data: `Can't save() the same doc multiple times in parallel`

To verify:
- [ ] Does this break anything else?
- [ ] Does anything else also need to be made async? (due to mongoose upgrade perhaps?)