### PR TITLE
Aggie CT pagination fix

### DIFF
--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -39,7 +39,7 @@
   "email": {
     "from": "Aggie <aggie@example.com>",
     "transport": {
-      "method_README": "Valid options: SES, SendGrid, SMTP (see mailer.js)"
+      "method_README": "Valid options: SES, SendGrid, SMTP (see mailer.js)",
       "method": "SES",
       "options": {
         "accessKeyId": "AWSAccessKeyId",

--- a/lib/fetching/content-service.js
+++ b/lib/fetching/content-service.js
@@ -9,6 +9,7 @@ var _ = require('underscore');
 // options.lastReportDate - The time of the last report already fetched (optional)
 var ContentService = function(options) {
   this._lastReportDate = options.lastReportDate;
+  this._nextPageUrl = options.nextPageUrl;
 };
 
 util.inherits(ContentService, EventEmitter);
@@ -21,18 +22,22 @@ ContentService.prototype.fetch = function(options, callback) {
   var self = this;
 
   // Fetch a chunk of reports (this is implemented by the child class).
-  this._doFetch({ maxCount: options.maxCount }, function(reportData) {
+  this._doFetch({ maxCount: options.maxCount }, function(responseData) {
 
     // Now that doFetch is over, we emit at most this._maxCount report data hashes, one at a time,
     // then call the callback.
     // _lastReportDate should end up as the time of the last emitted report.
     var emitted = 0;
-    _.sortBy(reportData, 'authoredAt').every(function(rd) {
-      self._lastReportDate = rd.authoredAt;
+    self._nextPageUrl = responseData.nextPageUrl;
+    _.sortBy(responseData.reportData, 'authoredAt').every(function(rd) {
+      if(self._lastReportDate === undefined){
+        self._lastReportDate = new Date(rd.authoredAt);
+      }
+      self._lastReportDate = self._lastReportDate > new Date(rd.authoredAt) ? self._lastReportDate: new Date(rd.authoredAt);
       self.emit('report', rd);
       return ++emitted < options.maxCount;
     });
-
+    
     callback(null, self._lastReportDate);
   });
 };

--- a/lib/fetching/content-services/crowd-tangle-content-service.js
+++ b/lib/fetching/content-services/crowd-tangle-content-service.js
@@ -12,6 +12,7 @@ var _ = require('underscore');
 //options.lastReportDate is passed here through the content-service-factory and will be utilised in calling the api, but its actually only maintained by the parent content service, it is only utilised by the child
 var CrowdTangleContentService = function(options) {
 	this._baseUrl = config.get().crowdtangle.baseUrl;
+	this._nextPageUrl = undefined;
 	this._pathName = config.get().crowdtangle.pathName;
 	this._count = config.get().crowdtangle.count;
 	this._language = config.get().crowdtangle.language;
@@ -21,7 +22,7 @@ var CrowdTangleContentService = function(options) {
 	this._lastReportDate = options._lastReportDate;
 	this._listIds = parseInt(options.tags);
 	this.fetchType = 'pull';
-	this.interval = 30000;
+	this.interval = 1000;
 	ContentService.call(this, options); //associates the child service with its parent, which has the notion of lastreportdate
 }
 
@@ -55,6 +56,7 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 			var responses;
 			try {
 				responses = JSON.parse(body).result.posts;
+				this._nextPageUrl = JSON.parse(body).result.pagination.nextPage;
 				if (!(responses instanceof Array)) {
 					self.emit('error', new Error('Wrong data'));
 					return callback([]);
@@ -67,7 +69,7 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 			// the responses will be sorted by the content-service (parent method)
 			// Parse response data and return them.
 			var reportData = responses.map(function(x) { return self._parse(x); });
-			callback(reportData);
+			callback({"nextPageUrl": this._nextPageUrl, "reportData": reportData});
 		})
 };
 
@@ -80,22 +82,30 @@ CrowdTangleContentService.prototype._completeUrl = function() {
 	// if it is the first time fetching data, initialize start date to an old date
 	var initialStartDate = new Date();
 	initialStartDate.setHours(initialStartDate.getHours() - 3);
-	var startDate = this._lastReportDate ? new Date(this._lastReportDate.getTime() + 1000).toISOString() : initialStartDate;
-	return url.format({
-		protocol: 'https',
-		hostname: this._baseUrl,
-		pathname: this._pathName,
-		query: {
-			token: this._apiToken,
-	    	count: this._count,
-	    	language: this._language,
-	    	listIds: this._listIds,
-	    	searchTerm: this._keywords,
-	    	sortBy: this._sortParameter,
-	    	startDate: startDate,
-			endDate: new Date().toISOString()
-		}
-	});
+	var startDate = this._lastReportDate ? new Date(this._lastReportDate.getTime() + 1000): initialStartDate;
+	if(this._nextPageUrl !== undefined && this._nextPageUrl !== null){
+		// this._nextPageUrl contains all information about language, searchTerm, sortBy etc. 
+		return url.format(this._nextPageUrl, {
+			protocol: 'https'
+		});
+	}
+	else{
+		return url.format({
+			protocol: 'https',
+			hostname: this._baseUrl,
+			pathname: this._pathName,
+			query: {
+				token: this._apiToken,
+				count: this._count,
+				language: this._language,
+				listIds: this._listIds,
+				searchTerm: this._keywords,
+				sortBy: this._sortParameter,
+				startDate: startDate.toISOString(),
+				endDate: new Date().toISOString()
+			}
+		});
+	}
 }
 
 CrowdTangleContentService.prototype._parse = function(data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,9 +4071,9 @@
       },
       "dependencies": {
         "gulp-cli": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-          "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+          "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
           "requires": {
             "ansi-colors": "^1.0.1",
             "archy": "^1.0.0",
@@ -4083,7 +4083,7 @@
             "copy-props": "^2.0.1",
             "fancy-log": "^1.3.2",
             "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
+            "interpret": "^1.4.0",
             "isobject": "^3.0.1",
             "liftoff": "^3.1.0",
             "matchdep": "^2.0.0",
@@ -4091,7 +4091,7 @@
             "pretty-hrtime": "^1.0.0",
             "replace-homedir": "^1.0.0",
             "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
+            "v8flags": "^3.2.0",
             "yargs": "^7.1.0"
           }
         }
@@ -4871,9 +4871,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "interval-to-human": {
       "version": "0.1.1",
@@ -11493,9 +11493,9 @@
       "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "v8flags": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -11838,9 +11838,9 @@
       }
     },
     "yargs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+      "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
       "requires": {
         "camelcase": "^3.0.0",
         "cliui": "^3.2.0",
@@ -11854,15 +11854,16 @@
         "string-width": "^1.0.2",
         "which-module": "^1.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^5.0.0"
+        "yargs-parser": "5.0.0-security.0"
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "version": "5.0.0-security.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+      "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "^3.0.0",
+        "object.assign": "^4.1.0"
       }
     },
     "yargs-unparser": {


### PR DESCRIPTION
- Crowdtangle posts are fetched using the Next Page URL in the paginated CT response. When the next page does not exist, Aggie makes a new call using the updated start date.

- Existing last report date functionality did not work with the paginated fetching. Updated it so that the last report date is always the max date (latest date) out of all the fetched posts.

Side note: I tested it myself multiple times but I would like any of you to test it out too because I think its a major change that could impact the number of posts we receive from CT.
