### PR TITLE
increased queue size

### DIFF
--- a/lib/fetching/circular-queue.js
+++ b/lib/fetching/circular-queue.js
@@ -13,7 +13,7 @@ var CircularQueue = function(capacity) {
   this.elements = new Array(this.capacity);
 };
 
-CircularQueue.DEFAULT_CAPACITY = 50;
+CircularQueue.DEFAULT_CAPACITY = 200;
 
 CircularQueue.prototype.add = function(element) {
   var end = (this.start + this.count) % this.capacity;


### PR DESCRIPTION
Increasing the queue size. Max number of posts in CT's response is 100. 50 was too less to consume all 100 posts every second. 

So increased it to 200. Potentially, it will help avoid dropping posts when the queue is full. 