### PR TITLE
Saved search fix

### DIFF
--- a/config/crowdtangle_list.json
+++ b/config/crowdtangle_list.json
@@ -1,4 +1,0 @@
-{
-	"crowdtangle_list_account_pairs": {
-	}
-}

--- a/lib/api/CT-list-update-service.js
+++ b/lib/api/CT-list-update-service.js
@@ -14,12 +14,13 @@ var CTListUpdateService = function(options) {
 }
 
 CTListUpdateService.prototype._updateCTList = async function() {
-    var content = { "crowdtangle_list_account_pairs": {} };
+    var content = { "crowdtangle_list_account_pairs": {}, "crowdtangle_saved_searches" : {}};
     await this._fetchLists();
     if (this._listResponse) {
         // build array of objects with list information
-        var lists = this._parseList(this._listResponse);
-
+        var parsedListResponse = this._parseList(this._listResponse);
+        var lists = parsedListResponse.lists;
+        var savedSearches = parsedListResponse.savedSearches;
         // request for accounts 
         while (lists.length !== 0) {
             var list = lists.shift();
@@ -47,35 +48,50 @@ CTListUpdateService.prototype._updateCTList = async function() {
             accountResponse.forEach(account => {
                 content.crowdtangle_list_account_pairs[account.id] = list.metadata.title;
             });
-        }; 
+        };
+        
+        while(savedSearches.length !== 0) {
+            var savedSearch = savedSearches.shift();
+            content.crowdtangle_saved_searches[savedSearch.list_id] = savedSearch.title;
+        }
     }
     // writes to JSON
     this._writeFile(content); 
     return content;
 }
-CTListUpdateService.prototype._parseList = function (listResponse) {
+CTListUpdateService.prototype._parseList = function (fetchedListsResponse) {
     // Builds an Object for each list and returns array of CT list information
-    var listResponse = listResponse.filter(listResponse => listResponse.type == "LIST" ? true : false);
-    return listResponse.map(listResponse => {
-        var idString = String(listResponse.id);
-        var title = String(listResponse.title);
-        var list = {};
-        list.metadata = {
-            list_id: idString,
-            title: title,
-        }
-        list.accountOptions = {
-            'method': 'GET',
-            'headers': this._headers,
-            'url': `https://api.crowdtangle.com/lists/${idString}/accounts`
-        };
-        return list;
-    });
+    var listResponse = fetchedListsResponse.filter(listResponse => listResponse.type == "LIST");
+    var savedSearchResponse = fetchedListsResponse.filter(listResponse => listResponse.type == "SAVED_SEARCH");
+    return {
+        "lists" : listResponse.map(listResponse => {
+            var idString = String(listResponse.id);
+            var title = String(listResponse.title);
+            var list = {};
+            list.metadata = {
+                list_id: idString,
+                title: title,
+            }
+            list.accountOptions = {
+                'method': 'GET',
+                'headers': this._headers,
+                'url': `https://api.crowdtangle.com/lists/${idString}/accounts`
+            };
+            return list;
+        }),
+        "savedSearches" : savedSearchResponse.map(savedSearchResponse => {
+            return {
+                list_id: savedSearchResponse.id,
+                title: String(savedSearchResponse.title)
+            }
+        })
+    
+    };
 }
 
 CTListUpdateService.prototype._writeFile = function (content) {
     // Writes input Object into json file
-    fs.writeFile(path.resolve(__dirname, this._outputDir), JSON.stringify(content, null, '\t'), function (err) {
+    fs.writeFileSync(path.resolve(__dirname, this._outputDir), JSON.stringify(content, null, '\t'), function (err) {
         if (err)
             throw err;
     });

--- a/lib/fetching/bots/pull-bot.js
+++ b/lib/fetching/bots/pull-bot.js
@@ -32,7 +32,7 @@ PullBot.prototype.stop = function() {
 PullBot.prototype.poll = function() {
   if (!this.enabled) return;
   var self = this;
-  this.fetch(function(err, lastReportDate) {
+  this.fetch(function(err, lastReportDate, lastReportDateSavedSearch) {
     if (err) {
       logger.warning(err);
     }
@@ -42,6 +42,10 @@ PullBot.prototype.poll = function() {
     // If fetch returned a lastReportDate, store it.
     if (lastReportDate && lastReportDate != -Infinity && self.source.lastReportDate !== lastReportDate) {
       self.source.lastReportDate = lastReportDate;
+      self.source.save();
+    }
+    if (lastReportDateSavedSearch && lastReportDateSavedSearch != -Infinity && self.source.lastReportDateSavedSearch !== lastReportDateSavedSearch) {
+      self.source.lastReportDateSavedSearch = lastReportDateSavedSearch;
       self.source.save();
     }
   });
@@ -58,9 +62,9 @@ PullBot.prototype.fetch = function(callback) {
 
   self._fetching = true;
 
-  this.contentService.fetch({ maxCount: maxCount }, function(err, lastReportDate) {
+  this.contentService.fetch({ maxCount: maxCount }, function(err, lastReportDate, lastReportDateSavedSearch) {
     self._fetching = false;
-    callback(err, lastReportDate);
+    callback(err, lastReportDate, lastReportDateSavedSearch);
   });
 };
 

--- a/lib/fetching/content-service-factory.js
+++ b/lib/fetching/content-service-factory.js
@@ -23,7 +23,7 @@ ContentServiceFactory.prototype.create = function(source) {
  
   var Service = contentServices[source.media];
   // Content services use only the lastReportDate, url, and keywords params.
-  var basicSource = _.pick(source, 'lastReportDate', 'url', 'keywords');
+  var basicSource = _.pick(source, 'lastReportDate', 'lastReportDateSavedSearch','url', 'keywords', 'tags');
 
   if (Service.fetchType === 'subscribe') {
     // There should only be one content service for this media

--- a/lib/fetching/content-service.js
+++ b/lib/fetching/content-service.js
@@ -10,6 +10,9 @@ var _ = require('underscore');
 var ContentService = function(options) {
   this._lastReportDate = options.lastReportDate;
   this._nextPageUrl = options.nextPageUrl;
+  this._nextPageUrlSavedSearch = options.nextPageUrlSavedSearch;
+  this._lastReportDateSavedSearch = options.lastReportDateSavedSearch;
+  this.savedSearchFetchEnabled = false;
 };
 
 util.inherits(ContentService, EventEmitter);
@@ -20,26 +23,45 @@ util.inherits(ContentService, EventEmitter);
 //   lastReportDate should be passed as an argument to the callback as shown.
 ContentService.prototype.fetch = function(options, callback) {
   var self = this;
-
-  // Fetch a chunk of reports (this is implemented by the child class).
-  this._doFetch({ maxCount: options.maxCount }, function(responseData) {
-
-    // Now that doFetch is over, we emit at most this._maxCount report data hashes, one at a time,
-    // then call the callback.
-    // _lastReportDate should end up as the time of the last emitted report.
-    var emitted = 0;
-    self._nextPageUrl = responseData.nextPageUrl;
-    _.sortBy(responseData.reportData, 'authoredAt').every(function(rd) {
-      if(self._lastReportDate === undefined){
-        self._lastReportDate = new Date(rd.authoredAt);
-      }
-      self._lastReportDate = self._lastReportDate > new Date(rd.authoredAt) ? self._lastReportDate: new Date(rd.authoredAt);
-      self.emit('report', rd);
-      return ++emitted < options.maxCount;
+  // Fetch a chunk of reports (this is implemented by the child class). Fetch reports alternatively from Lists and Saved Searches
+  if(!self.savedSearchFetchEnabled){
+    this._doFetch({ maxCount: options.maxCount, requestType: "LISTS" }, function(responseData) {
+      // Now that doFetch is over, we emit at most this._maxCount report data hashes, one at a time,
+      // then call the callback.
+      // _lastReportDate should end up as the time of the last emitted report.
+      var emitted = 0;
+      self._nextPageUrl = responseData.nextPageUrl;
+      _.sortBy(responseData.reportData, 'authoredAt').every(function(rd) {
+        if(self._lastReportDate === undefined){
+          self._lastReportDate = new Date(rd.authoredAt);
+        }
+        self._lastReportDate = self._lastReportDate > new Date(rd.authoredAt) ? self._lastReportDate: new Date(rd.authoredAt);
+        self.emit('report', rd);
+        return ++emitted < options.maxCount;
+      });
+      self.savedSearchFetchEnabled = true;
+      callback(null, self._lastReportDate, null);
     });
-    
-    callback(null, self._lastReportDate);
-  });
+  } else{
+    this._doFetch({ maxCount: options.maxCount, requestType: "SAVED_SEARCH" }, function(responseData) {
+
+      // Now that doFetch is over, we emit at most this._maxCount report data hashes, one at a time,
+      // then call the callback.
+      // _lastReportDateSavedSearch should end up as the time of the last emitted Saved Search report.
+      var emitted = 0;
+      self._nextPageUrlSavedSearch = responseData.nextPageUrl;
+      _.sortBy(responseData.reportData, 'authoredAt').every(function(rd) {
+        if(self._lastReportDateSavedSearch === undefined){
+          self._lastReportDateSavedSearch = new Date(rd.authoredAt);
+        }
+        self._lastReportDateSavedSearch = self._lastReportDateSavedSearch > new Date(rd.authoredAt) ? self._lastReportDateSavedSearch: new Date(rd.authoredAt);
+        self.emit('report', rd);
+        return ++emitted < options.maxCount;
+      });
+      self.savedSearchFetchEnabled = false;
+      callback(null, null, self._lastReportDateSavedSearch);
+    });
+  }
 };
 
 // Abstract method to be implemented by child classes to do actual fetching

--- a/lib/fetching/content-services/crowd-tangle-content-service.js
+++ b/lib/fetching/content-services/crowd-tangle-content-service.js
@@ -8,6 +8,7 @@ var util = require('util');
 var config = require('../../../config/secrets');
 var crowdtangle_lists = require('../../../config/crowdtangle_list');
 
+
 var request = require('request');
 var _ = require('underscore');
 
@@ -15,16 +16,17 @@ var _ = require('underscore');
 var CrowdTangleContentService = function(options) {
 	this._baseUrl = config.get().crowdtangle.baseUrl;
 	this._nextPageUrl = undefined;
+	this._nextPageUrlSavedSearch = undefined;
 	this._pathName = config.get().crowdtangle.pathName;
 	this._count = config.get().crowdtangle.count;
 	this._language = config.get().crowdtangle.language;
 	this._sortParameter = config.get().crowdtangle.sortParam;
 	this._apiToken = config.get().crowdtangle.apiToken;
 	this._keywords = options.keywords;
-	this._lastReportDate = options._lastReportDate;
-	this._listIds = parseInt(options.tags);
+	this._lastReportDate = options.lastReportDate;
+	this._lastReportDateSavedSearch = options.lastReportDateSavedSearch;
 	this.fetchType = 'pull';
-	this.interval = 1000;
+	this.interval = 10000;
 	ContentService.call(this, options); //associates the child service with its parent, which has the notion of lastreportdate
 }
 
@@ -44,8 +46,12 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 	// 	return callback([]);
 	// }
 
-	  //now we need to submit the request
-		this._httpRequest( {url: this._completeUrl(options)}, function(err, res, body) {
+	// now we need to submit the request
+
+	var  requestUrl = this._completeUrl(options)
+
+	if (requestUrl !== null){
+		this._httpRequest({url: requestUrl}, function(err, res, body) {
 			if (err) {
 				self.emit('error', new Error('HTTP error: ' + err.message));
 				return callback([]);
@@ -53,12 +59,12 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 				self.emit('error', new Error.HTTP(res.statusCode));
 				return callback([]);
 			}
-
+	
 			//if no errors, parse the body..
 			var responses;
 			try {
 				responses = JSON.parse(body).result.posts;
-				this._nextPageUrl = JSON.parse(body).result.pagination.nextPage;
+				var nextPageUrl = JSON.parse(body).result.pagination.nextPage;
 				if (!(responses instanceof Array)) {
 					self.emit('error', new Error('Wrong data'));
 					return callback([]);
@@ -70,28 +76,46 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 			}
 			// the responses will be sorted by the content-service (parent method)
 			// Parse response data and return them.
-			var reportData = responses.map(function(x) { return self._parse(x); });
-			callback({"nextPageUrl": this._nextPageUrl, "reportData": reportData});
-		})
+			var reportData = responses.map(function(x) { return self._parse(x, options); });
+			callback({"nextPageUrl": nextPageUrl, "reportData": reportData});
+		});
+	}
+	
 };
 
 CrowdTangleContentService.prototype._httpRequest = function(params, callback) {
 	request(params, callback);
 };
 
-CrowdTangleContentService.prototype._completeUrl = function() {
+CrowdTangleContentService.prototype._completeUrl = function(options) {
 	// add one second to last report date to start fetching from
 	// if it is the first time fetching data, initialize start date to an old date
 	var initialStartDate = new Date();
 	initialStartDate.setHours(initialStartDate.getHours() - 3);
-	var startDate = this._lastReportDate ? new Date(this._lastReportDate.getTime() + 1000): initialStartDate;
-	if(this._nextPageUrl !== undefined && this._nextPageUrl !== null) {
+	
+	//assigning correct value to lastReportDate based on whether the request is for SAVED_SEARCH or LIST
+	var lastReportDate =  this._lastReportDate;
+	var nextPageUrl = this._nextPageUrl;
+	var listIds = "";
+	if(options.requestType == "SAVED_SEARCH"){
+		lastReportDate = this._lastReportDateSavedSearch;
+		nextPageUrl = this._nextPageUrlSavedSearch;
+		listIds = Object.keys(crowdtangle_lists.crowdtangle_saved_searches).join(",");
+		//this ensures that if a user doesn't have saved search configured, Aggie doesnt make a Saved search request to CT
+		if(listIds == "") {
+			return null;
+		}
+	} 
+	
+	var startDate = lastReportDate ? new Date(lastReportDate.getTime() + 1000): initialStartDate;
+	if(nextPageUrl !== undefined && nextPageUrl !== null) {
 		// this._nextPageUrl contains all information about language, searchTerm, sortBy etc.
-		return url.format(this._nextPageUrl, {
+		var urlObj = url.format(nextPageUrl, {
 			protocol: 'https'
 		});
+		return urlObj;
 	} else {
-		return url.format({
+		var urlObj = url.format({
 			protocol: 'https',
 			hostname: this._baseUrl,
 			pathname: this._pathName,
@@ -99,17 +123,18 @@ CrowdTangleContentService.prototype._completeUrl = function() {
 				token: this._apiToken,
 				count: this._count,
 				language: this._language,
-				listIds: this._listIds,
+				listIds: listIds,
 				searchTerm: this._keywords,
 				sortBy: this._sortParameter,
 				startDate: startDate.toISOString(),
 				endDate: new Date().toISOString()
 			}
 		});
+		return urlObj;
 	}
 }
 
-CrowdTangleContentService.prototype._parse = function(data) {
+CrowdTangleContentService.prototype._parse = function(data, options) {
 
 	var metadata = {
 		sponsor: data.brandedContentSponsor	|| null,
@@ -137,10 +162,14 @@ CrowdTangleContentService.prototype._parse = function(data) {
 
 	// This code deals specifically with matching a crowdtangle list to a report's account id
 	this.crowdtangle_lists = crowdtangle_lists.crowdtangle_list_account_pairs;
+	this.crowdtangle_saved_searches = crowdtangle_lists.crowdtangle_saved_searches;
 	// If the list is found and matched, then the ct_tag is the list name
 	if (this.crowdtangle_lists[data.account.id]) {
 		metadata.ct_tag = this.crowdtangle_lists[data.account.id];
-	} else {
+	} else if (options.requestType == "SAVED_SEARCH") {
+		metadata.ct_tag = "Saved Search";
+	} 
+	else {
 		// If the list is not found and not matched, make the ct_tag the account.id so we can identify it later.
 		metadata.ct_tag = data.account.id;
 	}

--- a/models/source.js
+++ b/models/source.js
@@ -37,6 +37,7 @@ var sourceSchema = new mongoose.Schema({
   events: { type: Array, default: [] },
   unreadErrorCount: { type: Number, default: 0 },
   lastReportDate: Date,
+  lastReportDateSavedSearch: Date,
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: false },
   tags: { type: [String], default: [] }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -381,7 +381,7 @@
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -829,7 +829,7 @@
     "async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+      "integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA="
     },
     "async-done": {
       "version": "1.3.2",
@@ -1669,7 +1669,7 @@
     "clarinet": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.4.tgz",
-      "integrity": "sha512-Rx9Zw8KQkoPO3/O2yPRchCZm3cGubCQiRLmmFAlbkDKobUIPP3JYul+bKILR9DIv1gSVwPQSgF8JGGkXzX8Q0w==",
+      "integrity": "sha1-XXGWorI0f/KD2y4r8e9hXAqmr9s=",
       "dev": true
     },
     "class-utils": {
@@ -2022,7 +2022,7 @@
     "connect-mongo": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-3.2.0.tgz",
-      "integrity": "sha512-0Mx88079Z20CG909wCFlR3UxhMYGg6Ibn1hkIje1hwsqOLWtL9HJV+XD0DAjUvQScK6WqY/FA8tSVQM9rR64Rw==",
+      "integrity": "sha1-IPd2x/Kp2BRPx2z9y/M+2wXrTVI=",
       "requires": {
         "mongodb": "^3.1.0"
       }
@@ -3499,7 +3499,7 @@
         "qs": {
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+          "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
         }
       }
     },
@@ -3525,7 +3525,7 @@
     "feedparser": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/feedparser/-/feedparser-2.2.10.tgz",
-      "integrity": "sha512-WoAOooa61V8/xuKMi2pEtK86qQ3ZH/M72EEGdqlOTxxb3m6ve1NPvZcmPFs3wEDfcBbFLId2GqZ4YjsYi+h1xA==",
+      "integrity": "sha1-0/pQnn1kdh36A3u75WPfnVLfsDg=",
       "requires": {
         "addressparser": "^1.0.1",
         "array-indexofobject": "~0.0.1",
@@ -3541,7 +3541,7 @@
         "sax": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+          "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
         }
       }
     },
@@ -4057,7 +4057,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
     },
     "growl": {
       "version": "1.9.2",
@@ -4067,7 +4067,7 @@
     "gulp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
-      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+      "integrity": "sha1-VDZRBw/Q9qsKBlDGo+b/WnywnKo=",
       "requires": {
         "glob-watcher": "^5.0.3",
         "gulp-cli": "^2.2.0",
@@ -4078,7 +4078,7 @@
         "gulp-cli": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
-          "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+          "integrity": "sha1-7A04DinlKqReR5d/DTLhj9FhEi8=",
           "requires": {
             "ansi-colors": "^1.0.1",
             "archy": "^1.0.0",
@@ -4174,7 +4174,7 @@
     "gulp-livereload": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-4.0.2.tgz",
-      "integrity": "sha512-InmaR50Xl1xB1WdEk4mrUgGHv3VhhlRLrx7u60iY5AAer90FlK95KXitPcGGQoi28zrUJM189d/h6+V470Ncgg==",
+      "integrity": "sha1-/Ip1x1Ec1lr9IgLLzci7D43eN3s=",
       "requires": {
         "chalk": "^2.4.1",
         "debug": "^3.1.0",
@@ -4188,7 +4188,7 @@
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4291,7 +4291,7 @@
     "gulp-ng-annotate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gulp-ng-annotate/-/gulp-ng-annotate-2.1.0.tgz",
-      "integrity": "sha512-wjazOa5qE83akCih+lK2a0LFvkLbIMeblxr54ofmc3WKJ3Ipx/BM98ZCtCDfQW/008EVUSRqwfEjFKEEGI0QbA==",
+      "integrity": "sha1-UL0ge0QDu8jw79AbztssyMBKkos=",
       "dev": true,
       "requires": {
         "bufferstreams": "^1.1.0",
@@ -4305,7 +4305,7 @@
     "gulp-plumber": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.2.1.tgz",
-      "integrity": "sha512-mctAi9msEAG7XzW5ytDVZ9PxWMzzi1pS2rBH7lA095DhMa6KEXjm+St0GOCc567pJKJ/oCvosVAZEpAey0q2eQ==",
+      "integrity": "sha1-04cAdVowC503Ixjk/7X/fO0LLIQ=",
       "requires": {
         "chalk": "^1.1.3",
         "fancy-log": "^1.3.2",
@@ -4340,12 +4340,12 @@
     "gulp-rename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
-      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ=="
+      "integrity": "sha1-m7w5YrDA9S/GfNXq/2wiPsW5z2w="
     },
     "gulp-sourcemaps": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz",
-      "integrity": "sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==",
+      "integrity": "sha1-o/AC2HNG0sDzrsNq9+uHPyPeiuY=",
       "dev": true,
       "requires": {
         "@gulp-sourcemaps/identity-map": "1.X",
@@ -4364,13 +4364,13 @@
         "acorn": {
           "version": "5.7.4",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "integrity": "sha1-Po2KmUfQWZoXltECJddDL0pKz14=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -4387,7 +4387,7 @@
     "gulp-uglify": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
-      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
+      "integrity": "sha1-X1sugzf4ecqd7Jcf6xuCpah4ULA=",
       "dev": true,
       "requires": {
         "array-each": "^1.0.1",
@@ -5845,7 +5845,7 @@
     "karma-browserify": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-7.0.0.tgz",
-      "integrity": "sha512-SLgh1dmF2eZEj3glrmTD2CMJRGZwEiKA6k2hBr2+2JDC4JMU1dlsvBKpV66Lvi/tbj3H9qA+Vl/FdIcfPRrJpA==",
+      "integrity": "sha1-YPRD+ZHs+7+1c3qf125zuLbrmlc=",
       "dev": true,
       "requires": {
         "convert-source-map": "^1.1.3",
@@ -5910,7 +5910,7 @@
     "karma-mocha": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-2.0.1.tgz",
-      "integrity": "sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==",
+      "integrity": "sha1-SwJUoY3+5xvb5hiNmmhhv4awzX0=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.3"
@@ -6456,7 +6456,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
     },
     "method-override": {
       "version": "2.3.10",
@@ -6517,7 +6517,7 @@
     "migrate": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.7.0.tgz",
-      "integrity": "sha512-I63YykITgWyI+ET4KO8xGePYkR9U7CtSe/RrR13vLbZSpUcAh4/ry2GswNv7Lywcsp3BaDHj7YdjC7ihVYCFmw==",
+      "integrity": "sha1-I/uXqjMUV4gDChqRGHoO4ypJrL8=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -6533,19 +6533,19 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
           "dev": true
         },
         "dateformat": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+          "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -6649,7 +6649,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -7091,7 +7091,7 @@
     "mongoose-sequence": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/mongoose-sequence/-/mongoose-sequence-5.2.2.tgz",
-      "integrity": "sha512-gtN33C4fXVgOH8SSQvwSf8+DcFtxw1n/Wk1RHEs+W3A/cqYgLjvjMalq/0q/TDboeapNi6RBymBnyw3fDoaDlg==",
+      "integrity": "sha1-i0DhOnrQ8Rqa/ZWtixITHSroYD0=",
       "requires": {
         "async": "^2.5.0",
         "lodash": "^4.17.11"
@@ -7100,7 +7100,7 @@
         "async": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
           "requires": {
             "lodash": "^4.17.14"
           }
@@ -7295,7 +7295,7 @@
     "nconf": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "integrity": "sha1-2hKF7pXQqSLKbO51rc+GH0ggWtI=",
       "requires": {
         "async": "^1.4.0",
         "ini": "^1.3.0",
@@ -7565,7 +7565,7 @@
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -7580,7 +7580,7 @@
     "nodemailer-sendgrid": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/nodemailer-sendgrid/-/nodemailer-sendgrid-1.0.3.tgz",
-      "integrity": "sha512-To/veO2M4evjtv1XrY7BUgE+LDypgs/FBx4wOHb2UNTpvZhiARtvMaBI0685Yxkho0lIPJc4jS0cUE7v+XGNgg==",
+      "integrity": "sha1-j4eGqf70+qlMSwoQdUf5I+nW6oU=",
       "requires": {
         "@sendgrid/mail": "^6.2.1"
       }
@@ -8112,7 +8112,7 @@
     "passport": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "integrity": "sha1-lBRGohy5L8aI2XoIYcOM6fc48nA=",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -8735,7 +8735,7 @@
     "protractor": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-7.0.0.tgz",
-      "integrity": "sha512-UqkFjivi4GcvUQYzqGYNe0mLzfn5jiLmO8w9nMhQoJRLhy2grJonpga2IWhI6yJO30LibWXJJtA4MOIZD2GgZw==",
+      "integrity": "sha1-w+JjYIvXLiwtyAKxGncnEaR5LQM=",
       "dev": true,
       "requires": {
         "@types/q": "^0.0.32",
@@ -8912,7 +8912,7 @@
         "webdriver-manager": {
           "version": "12.1.7",
           "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
-          "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
+          "integrity": "sha1-7U6u6PkGszwUboabVehQVTobEWI=",
           "dev": true,
           "requires": {
             "adm-zip": "^0.4.9",
@@ -9301,7 +9301,7 @@
     "readline-sync": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+      "integrity": "sha1-Qd9/u0tjEtZzARWUFFcFv1bYhzs="
     },
     "rechoir": {
       "version": "0.6.2",
@@ -9394,7 +9394,7 @@
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -9421,12 +9421,12 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
         }
       }
     },
@@ -9442,7 +9442,7 @@
     "request-promise": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "integrity": "sha1-fn5blXhjDm9ZjjgTwPjrNCon8KI=",
       "requires": {
         "bluebird": "^3.5.0",
         "request-promise-core": "1.1.4",
@@ -10372,7 +10372,7 @@
     "socket.io-client": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "integrity": "sha1-FNW6LgC5vNFFrkQ6uWs/hsvMG7Q=",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
@@ -10398,7 +10398,7 @@
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10411,7 +10411,7 @@
         "socket.io-parser": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "integrity": "sha1-K1KpalCf3zFEC6QP7WCUx9TxJi8=",
           "requires": {
             "component-emitter": "1.2.1",
             "debug": "~3.1.0",
@@ -10421,7 +10421,7 @@
             "debug": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
               "requires": {
                 "ms": "2.0.0"
               }
@@ -10922,7 +10922,7 @@
     "supertest": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
-      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "integrity": "sha1-wiNNvdbcebbxW5nI1ld7kOTOPzY=",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",
@@ -11055,7 +11055,7 @@
     "timekeeper": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
-      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A=="
+      "integrity": "sha1-lkVzH86eMoChhhSlep0bcq88o2g="
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -11078,7 +11078,7 @@
     "timezone": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/timezone/-/timezone-1.0.23.tgz",
-      "integrity": "sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA=="
+      "integrity": "sha1-h4ZeLJ1q/2pSpZgkfo9RAqksiBs="
     },
     "tiny-lr": {
       "version": "1.1.1",
@@ -11274,7 +11274,7 @@
     "twit": {
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/twit/-/twit-2.2.11.tgz",
-      "integrity": "sha512-BkdwvZGRVoUTcEBp0zuocuqfih4LB+kEFUWkWJOVBg6pAE9Ebv9vmsYTTrfXleZGf45Bj5H3A1/O9YhF2uSYNg==",
+      "integrity": "sha1-VUND0c80Pd9QMoDbgh9hvlq0B8M=",
       "requires": {
         "bluebird": "^3.1.5",
         "mime": "^1.3.4",
@@ -11375,7 +11375,7 @@
     "underscore": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+      "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8="
     },
     "undertaker": {
       "version": "1.2.1",


### PR DESCRIPTION
- Adding support for getting posts from Saved Searches on CT

- Aggie alternates between requesting posts from lists and posts from saved searches. This had to be done because CT won't include posts from saved searches in the normal /posts endpoint without list ids. 

- Changed the script that makes CT list <->acct pairs to also include information on saved searches.
