### PR TITLE
Fixed error in security update to CT List output directory

### DIFF
--- a/lib/api/CT-list-update-service.js
+++ b/lib/api/CT-list-update-service.js
@@ -91,7 +91,7 @@ CTListUpdateService.prototype._parseList = function (fetchedListsResponse) {
 
 CTListUpdateService.prototype._writeFile = function (content) {
     // Writes input Object into json file
-    fs.writeFileSync(path.resolve(__dirname, this._outputDir), JSON.stringify(content, null, '\t'), function (err) {
+    fs.writeFileSync(path.resolve(__dirname, this.OUTPUT_DIR), JSON.stringify(content, null, '\t'), function (err) {
         if (err)
             throw err;
     });


### PR DESCRIPTION
When I merged the previous fix #362, it had overwritten a line and forgot to update a variable name. I have resolved that here.

This version still fails the last two tests in `test/backend/lib.api.CT-list-update-service.test.js`, but that appears to be a problem with something else, not my updates. The last test specifically seems to fail because the custom `_parseList()` function that is used for the test structures its return value in an unexpected way. 