### PR TITLE
Update to remove Autoadd Tags for CT posts

### DIFF
--- a/lib/fetching/bot.js
+++ b/lib/fetching/bot.js
@@ -102,9 +102,6 @@ Bot.prototype._reportListener = function(reportData) {
       if (reportData._media === 'twitter') {
         reportData.metadata.retweet ? reportData.tags.push('RT') : reportData.tags.push('NO_RT');
       }
-      if (reportData._media === 'facebook') {
-        true ? reportData.tags.push(reportData.metadata.ct_tag) : reportData.tags.push('Untagged');
-      }
     }
 
     var drops = this.queue.drops;


### PR DESCRIPTION
Originally we used tags as the method to store list names. We have since created a system to store CT List data in the report metadata. This is now no longer useful.