### PR TITLE
Incident Modal Text Wrap Fix 

### DIFF
--- a/public/angular/sass/components/tables.scss
+++ b/public/angular/sass/components/tables.scss
@@ -303,11 +303,26 @@ td {
   background-color: #f5f6f7;
 }
 
-.td__location {
+.table__incidentTitle {
+  max-width: 10vw;
+}
+
+.modal__incidentTitle {
+  max-width: 100px;
+  word-wrap: break-word;
+}
+
+.modal__location {
+  max-width: 160px;
+  word-wrap: break-word;
+}
+.table__location {
   max-width: 200px;
 }
+
 .td__tags {
   max-width: 180px;
+  word-wrap: break-word;
 }
 
 .td__flag {

--- a/public/angular/sass/components/tables.scss
+++ b/public/angular/sass/components/tables.scss
@@ -354,6 +354,8 @@ tag.tr__tag {
 
 .td__incident {
   position: relative;
+  max-width: 120px;
+  word-wrap: break-word;
 }
 
 .content__shared {

--- a/public/angular/templates/incidents/table.html
+++ b/public/angular/templates/incidents/table.html
@@ -1,3 +1,4 @@
+<!-- TODO: Make this into two different files for clarity -->
 <div class="table-responsive">
   <table class="table table-sm" ng-show="pagination.total > 0 || modal" ng-class="{'table-hover': modal}">
     <thead>
@@ -23,13 +24,13 @@
       <td>
         <strong>{{ i.idnum + 1 | tripleDigit }}</strong>
       </td>
-      <td>
+      <td ng-class="modal ? 'modal__incidentTitle' : 'table__incidentTitle'">
         <a ng-hide="modal" href="incidents/{{i._id}}" class="table-primary-link">{{ i.title }}</a>
         <strong ng-show="modal">{{ i.title }}</strong>
         <br />
         <span class="text-muted">{{i.totalReports}} {{'reports' | translate}}</span>
       </td>
-      <td class="td__location">
+      <td ng-class = "modal ? 'modal__location' : 'table__location'">
         <div class="map-marker" ng-show="i.latitude && i.longitude"></div>
         <span ng-if="i.locationName">{{ i.locationName }}</span>
         <span ng-if="!i.locationName && i.latitude && i.longitude">{{ i.latitude | number:6 }}, {{ i.longitude | number:6 }}</span>
@@ -43,17 +44,18 @@
           <span ng-if="!i.veracity" class="text-red" translate>False</span>
         </div>
       </td>
-      <td>{{ {false: 'No', true: 'Yes'}[i.escalated] | translate }}</td>
-      <td class="td__tags">{{ tagsToString(i.tags) }}</td>
+      <td class="table__escalated" title="{{'Escalated?' | translate}}">
+        <span>{{ {false: 'No', true: 'Yes'}[i.escalated] | translate }}</span>
+      </td>
+      <td class="td__tags" title="{{'Tags' | translate}}">
+        <span>{{ tagsToString(i.tags) }}</span>
+      </td>
       <td>
-        <div class="interval">
-          <span class="interval-amount">{{ i.updatedAt | interval }}</span>
-          <span class="interval-relative" translate>ago</span>
-        </div>
-        <div class="date-and-time">
-          <span class="time">{{ i.updatedAt | aggieDate:'time' }}</span>
-          <span class="date">{{ i.updatedAt | aggieDate:'date' }}</span>
-        </div>
+        <span class="badge badge-pill badge-secondary mb-2" title="">{{ i.storedAt | interval }} ago</span>
+        <br>
+        <small class="time">{{ i.updatedAt | aggieDate:'time' }}</small>
+        <br>
+        <small> {{ i.updatedAt | aggieDate:'date' }}</small>
       </td>
       <td ng-hide="modal ||  !currentUser.can('edit data')" class="compact actions">
         <div class="fa fa-pencil text-blue td__edit" ng-controller="IncidentFormModalController" ng-click="edit(i)"></div>

--- a/public/angular/templates/reports/table.html
+++ b/public/angular/templates/reports/table.html
@@ -19,7 +19,7 @@
           </div>
         </td>
         <td class="td__sourceInfo">
-          <span class="badge badge-pill badge-secondary mb-2">{{ r.storedAt | interval }} ago</span>
+          <span class="badge badge-pill badge-secondary mb-2" title="{{ r.storedAt | aggieDate:'date' }} at {{ r.storedAt | aggieDate:'short_time' }}">{{ r.storedAt | interval }} ago</span>
           <p class="sourceInfo__author">
             <i class="fa fa-user-circle-o author__icon" aria-hidden="true"></i>
               {{ r.author }}


### PR DESCRIPTION
Fixed text exiting columns in the add report to incident modal. Also added an upper limit to the width the incident column can take given a large incident title. 