### PR TITLE
Lower cache time to 10 min

### DIFF
--- a/docs/content/aggie-nginx
+++ b/docs/content/aggie-nginx
@@ -35,10 +35,10 @@ server {
   index index.html;
 
   # nginx to serve static files rather than Aggie
-  location ~ ^/(js|templates|translations) {
-    # Modify /etc/nginx/nginx.conf to enable the the compression of js, css and other file types
+  location ~ ^/(js|css|images|templates|translations)/ {
     sendfile on;
-    expires 24h;
+    # Cache for 10 minutes, so things update quickly after aggie is deployed.
+    expires 600;
     add_header Cache-Control public;
 
     # XXX NEEDS CUSTOMIZATION.


### PR DESCRIPTION
And include some missing directories so they're cached consistently. Nice docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

This needs to be deployed manually in `/etc/nginx/sites-available/aggie.conf`. I've tested and verified on aggie-beta.

The "right way" to do this would be auto-appending unique hashes to build artifacts (like all JS files) so they're cached for a long time but instantly update when we deploy something new. I don't trust an old version of angular to do this effectively with our setup so this is good enough for now.