### PR TITLE
Default CT useLanguage to false

### DIFF
--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -8,11 +8,12 @@
   "crowdtangle": {
     "apiToken": "Enter API Token",
     "baseUrl": "api.crowdtangle.com",
-    "pathName" : "/posts",
+    "pathName": "/posts",
     "count": 100,
     "sortParam": "date",
     "language": "en",
-    "zawgyiProb" : 0.9
+    "useLanguage": false,
+    "zawgyiProb": 0.9
   },
   "elmo": {
     "authToken": "Enter Auth Token"
@@ -102,5 +103,5 @@
   "experimentFile": "test/end-to-end/fixtures/experiment_reports.json",
   "adminPassword": "letmein1",
   "adminEmail": "aggie-admin@example.com",
-  "detectHateSpeech" : false
+  "detectHateSpeech": false
 }

--- a/lib/fetching/content-services/crowd-tangle-content-service.js
+++ b/lib/fetching/content-services/crowd-tangle-content-service.js
@@ -14,14 +14,9 @@ var _ = require('underscore');
 
 //options.lastReportDate is passed here through the content-service-factory and will be utilised in calling the api, but its actually only maintained by the parent content service, it is only utilised by the child
 var CrowdTangleContentService = function(options) {
-	this._baseUrl = config.get().crowdtangle.baseUrl;
 	this._nextPageUrl = undefined;
 	this._nextPageUrlSavedSearch = undefined;
-	this._pathName = config.get().crowdtangle.pathName;
-	this._count = config.get().crowdtangle.count;
-	this._language = config.get().crowdtangle.language;
-	this._sortParameter = config.get().crowdtangle.sortParam;
-	this._apiToken = config.get().crowdtangle.apiToken;
+	this.reloadSettings();
 	this._keywords = options.keywords;
 	this._lastReportDate = options.lastReportDate;
 	this._lastReportDateSavedSearch = options.lastReportDateSavedSearch;
@@ -237,6 +232,8 @@ CrowdTangleContentService.prototype.reloadSettings = function() {
 	this._pathName = config.get().crowdtangle.pathName;
 	this._count = config.get().crowdtangle.count;
 	this._language = config.get().crowdtangle.language;
+	this._sortParameter = config.get().crowdtangle.sortParam;
+	this._apiToken = config.get().crowdtangle.apiToken;
 };
 
 CrowdTangleContentService.prototype.reloadCTList = function() {

--- a/lib/fetching/content-services/crowd-tangle-content-service.js
+++ b/lib/fetching/content-services/crowd-tangle-content-service.js
@@ -59,7 +59,7 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 				self.emit('error', new Error.HTTP(res.statusCode));
 				return callback([]);
 			}
-	
+
 			//if no errors, parse the body..
 			var responses;
 			try {
@@ -92,12 +92,12 @@ CrowdTangleContentService.prototype._doFetch = function(options, callback) {
 				var reportData = responses.map(function(x) { return self._parse(x, options); });
 				callback({"nextPageUrl": nextPageUrl, "reportData": reportData});
 			}
-			
+
 		});
 	} else {
 		callback({});
 	}
-	
+
 };
 
 CrowdTangleContentService.prototype._httpRequest = function(params, callback) {
@@ -109,7 +109,7 @@ CrowdTangleContentService.prototype._completeUrl = function(options) {
 	// if it is the first time fetching data, initialize start date to an old date
 	var initialStartDate = new Date();
 	initialStartDate.setHours(initialStartDate.getHours() - 3);
-	
+
 	//assigning correct value to lastReportDate based on whether the request is for SAVED_SEARCH or LIST
 	var lastReportDate =  this._lastReportDate;
 	var nextPageUrl = this._nextPageUrl;
@@ -122,8 +122,8 @@ CrowdTangleContentService.prototype._completeUrl = function(options) {
 		if(listIds == "") {
 			return null;
 		}
-	} 
-	
+	}
+
 	var startDate = lastReportDate ? new Date(lastReportDate.getTime() + 1000): initialStartDate;
 	if(nextPageUrl !== undefined && nextPageUrl !== null) {
 		// this._nextPageUrl contains all information about language, searchTerm, sortBy etc.
@@ -177,7 +177,7 @@ CrowdTangleContentService.prototype._parse = function(data, options) {
 
 	var author = data.account ? data.account.name || data.account.handle : null;
 	var content = data.message || 'No Content'
-	
+
 	// This code deals specifically with matching a crowdtangle list to a report's account id
 	this.crowdtangle_lists = crowdtangle_lists.crowdtangle_list_account_pairs;
 	this.crowdtangle_saved_searches = crowdtangle_lists.crowdtangle_saved_searches;
@@ -187,7 +187,7 @@ CrowdTangleContentService.prototype._parse = function(data, options) {
 	} else if (options.requestType == "SAVED_SEARCH") {
 		metadata.ct_tag = []
 		// This is a workaround to identify possible saved search names associated with a post using substring search.
-		// We plan to remove this workaround when CT adds list IDs/account IDs to saved search API responses.  
+		// We plan to remove this workaround when CT adds list IDs/account IDs to saved search API responses.
 		for(var saved_search_id in this.crowdtangle_saved_searches){
 			var saved_search = this.crowdtangle_saved_searches[saved_search_id];
 			const doesMatch = this.doesReportMatchWords(saved_search.words, content, metadata)
@@ -197,7 +197,7 @@ CrowdTangleContentService.prototype._parse = function(data, options) {
 		if(metadata.ct_tag.length == 0){
 			metadata.ct_tag.push("Saved Search");
 		}
-	} 
+	}
 	else {
 		// If the list is not found and not matched, make the ct_tag the account.id so we can identify it later.
 		metadata.ct_tag = data.account.id;
@@ -219,10 +219,10 @@ CrowdTangleContentService.prototype._parse = function(data, options) {
 CrowdTangleContentService.prototype.doesReportMatchWords = function(words, content, metadata) {
 	try{
 		var regex = new RegExp(words.join("|"), 'gi');
-		if (words.length && 
-			(regex.test(content)|| 
-			regex.test(metadata.caption) || 
-			regex.test(metadata.title) || 
+		if (words.length &&
+			(regex.test(content)||
+			regex.test(metadata.caption) ||
+			regex.test(metadata.title) ||
 			regex.test(metadata.description)||
 			regex.test(metadata.imageText))) {
 				return true;

--- a/lib/fetching/content-services/crowd-tangle-content-service.js
+++ b/lib/fetching/content-services/crowd-tangle-content-service.js
@@ -231,7 +231,8 @@ CrowdTangleContentService.prototype.reloadSettings = function() {
 	this._baseUrl = config.get().crowdtangle.baseUrl;
 	this._pathName = config.get().crowdtangle.pathName;
 	this._count = config.get().crowdtangle.count;
-	this._language = config.get().crowdtangle.language;
+	const useLanguage = config.get().crowdtangle.useLanguage;
+	this._language = useLanguage ? config.get().crowdtangle.language : undefined;
 	this._sortParameter = config.get().crowdtangle.sortParam;
 	this._apiToken = config.get().crowdtangle.apiToken;
 };


### PR DESCRIPTION
The idea is, instead of manually commenting out code on each machine, we can just default `useLanguage` to `false`. Then we don't need to maintain a git diff and stash/pop every time we deploy. This PR won't even require a config change on any machine since it's off by default.

I've tested this locally, just want to have @harshilshah4251 confirm that this makes sense.