### PR TITLE
removed relative paths in hs clf python file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ public/angular/css/app.css
 public/angular/js/app.min.js
 public/angular/translations/locale-debug.json
 lib/translations/locale-debug.json
-
+hate-speech-api/error.log
 config/secrets.json
 
 buildAssets

--- a/hate-speech-api/hate_speech_clf_api.py
+++ b/hate-speech-api/hate_speech_clf_api.py
@@ -7,16 +7,18 @@ from data_processing.mm_converter import zawgyi_to_unicode
 import re
 import json
 from sklearn.ensemble import RandomForestClassifier
+import os
 
 app = Flask(__name__)
+dir_path = os.path.dirname(os.path.abspath(__file__))
 
 class HateSpeechClassifier(FlaskView):
 
     def __init__(self):
         self.burmese_segmenter = mm.Segmenter()
-        with open("models/vectorizers/oversampled-tfidf-vect.pkl", 'rb') as vect_b:
+        with open(os.path.join(dir_path, "models/vectorizers/oversampled-tfidf-vect.pkl"), 'rb') as vect_b:
             self.vectorizer = pickle.load(vect_b)
-        with open("models/clfs/oversampled-RFClf-tfidf.pkl", 'rb') as clf_b:
+        with open(os.path.join(dir_path,"models/clfs/oversampled-RFClf-tfidf.pkl"), 'rb') as clf_b:
             self.model = pickle.load(clf_b)
 
     #Internal functions. Not exposed via API    


### PR DESCRIPTION
removed relative paths in hs clf python file because the script couldnt be executed from outside of the directory otherwise. 