### PR TITLE
Return of Tag Modal Because Comments are on a Different Branch

### DIFF
--- a/public/angular/js/controllers/reports/index.js
+++ b/public/angular/js/controllers/reports/index.js
@@ -522,7 +522,6 @@ angular.module('Aggie')
 
     // Batch Mode Functions
     $scope.grabBatch = function() {
-      $scope.searchParams.tags = $scope.searchParams.tags;
       Batch.checkout($scope.searchParams, function(resource) {
         // no more results found
         if (!resource.results || !resource.results.length) {

--- a/public/angular/templates/reports/content-services/crowd-tangle-show.html
+++ b/public/angular/templates/reports/content-services/crowd-tangle-show.html
@@ -57,10 +57,10 @@
                           <span ng-repeat="tag in report.tags">
                             {{ tag + ', '}}
                           </span>
-            <!-- see reports index.html to why this is
+            <!-- see reports index.html to why this is -->
             <a ng-controller="SMTCTagSelectModalController" ng-click="setSMTCTags(report)" class="table-primary-link">
-              <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit</strong>
-            </a>-->
+              <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit Tags</strong>
+            </a>
             <tags class="tagify readonly" tabindex="-1">
               <tag ng-repeat="tag in report.smtcTags" contenteditable="false" spellcheck="false" tabindex="-1"
                    class="tr__tag tagify__tag tagify" __isvalid="true" value="bar" ng-style="{'--tag-bg': smtcTagsById[tag].color}">

--- a/public/angular/templates/reports/content-services/twitter-show.html
+++ b/public/angular/templates/reports/content-services/twitter-show.html
@@ -82,11 +82,11 @@
                           <span ng-repeat="tag in report.tags">
                             {{ tag + ', '}}
                           </span>
-            <!-- See reports index.html to see why this is removed
+            <!-- See reports index.html to see why this is removed -->
             <a ng-controller="SMTCTagSelectModalController" ng-click="setSMTCTags(report)" class="table-primary-link">
-              <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit</strong>
+              <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit Tags</strong>
             </a>
-            -->
+
             <tags class="tagify readonly" tabindex="-1">
               <tag ng-repeat="tag in report.smtcTags" contenteditable="false" spellcheck="false" tabindex="-1"
                    class="tr__tag tagify__tag tagify" __isvalid="true" value="bar" ng-style="{'--tag-bg': smtcTagsById[tag].color}">

--- a/public/angular/templates/reports/show.html
+++ b/public/angular/templates/reports/show.html
@@ -78,8 +78,9 @@
                           <span ng-repeat="tag in report.tags">
                             {{ tag + ', '}}
                           </span>
+                        <!-- See why Tag Modal isn't going to work with comments on table.html-->
                         <a ng-controller="SMTCTagSelectModalController" ng-click="setSMTCTags(report)" class="table-primary-link">
-                          <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit</strong>
+                          <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit Tags</strong>
                         </a>
                         <tags class="tagify readonly" tabindex="-1">
                           <tag ng-repeat="tag in report.smtcTags" contenteditable="false" spellcheck="false" tabindex="-1"

--- a/public/angular/templates/reports/table.html
+++ b/public/angular/templates/reports/table.html
@@ -60,11 +60,9 @@
           <span ng-if="r.tags" ng-class="{ strong: !isRead(r) }">
             {{tagsToString(r.tags) + ", "}}
           </span>
-          <!--
           <a ng-controller="SMTCTagSelectModalController" ng-click="setSMTCTags(r)" class="table-primary-link">
             <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit Tags</strong>
           </a>
-          -->
           <tags class="tagify readonly" tabindex="-1">
             <tag ng-repeat="tag in r.smtcTags" contenteditable="false" spellcheck="false" tabindex="-1"
                  class="tags__tag tr__tag tagify__tag tagify" __isvalid="true" value="bar"

--- a/public/angular/templates/reports/tableBatch.html
+++ b/public/angular/templates/reports/tableBatch.html
@@ -60,11 +60,10 @@
           <span ng-if="r.tags" ng-class="{ strong: !isRead(r) }">
             {{tagsToString(r.tags) + ", "}}
           </span>
-          <!-- See table.html for reason for commenting out.
+          <!-- See table.html for reason for commenting out. -->
           <a ng-controller="SMTCTagSelectModalController" ng-click="setSMTCTags(r)" class="table-primary-link">
-            <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit</strong>
+            <strong class="addIdentifier" ng-if="currentUser.can('edit data')" translate>Edit Tags</strong>
           </a>
-          -->
           <tags class="tagify readonly" tabindex="-1">
             <tag ng-repeat="tag in r.smtcTags" contenteditable="false" spellcheck="false" tabindex="-1"
                  class="tags__tag tr__tag tagify__tag tagify" __isvalid="true" value="bar"


### PR DESCRIPTION
I'm returning the tag modal for now because we're developing comments on a different branch and I removed it for comments.