### PR TITLE
fix: disable sending of response after timeout

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -83,8 +83,10 @@ function handleRequestTimeouts(req, res, next) {
   res.end = function(chunk, encoding) {
     clearTimeout(timeoutId);
 
-    res.end = end;
-    res.end(chunk, encoding);
+    if (!res.headersSent) {
+      res.end = end;
+      res.end(chunk, encoding);
+    }
   };
 
   next();


### PR DESCRIPTION
When an endpoint times out, a timeout middleware function sends a `500 Internal Server Error` response status code back to the client. If the request completes after the timeout has occurred, it tries to send a response status code after the initial response was already sent by the timeout middleware.

This PR introduces a check to the`res.end` function modified  by the timeout middleware so that a response will only be sent if one has not been sent already. There are deeper, systematic problems with the way in which these endpoints have been designed - for example, the timeout should ideally occur through an endpoint, such that it stops its own operation prematurely - but those can be addressed at a later time.