### PR TITLE
Event Emitter Memory Leak Fix

### DIFF
--- a/lib/api/socket-handler.js
+++ b/lib/api/socket-handler.js
@@ -57,6 +57,7 @@ SocketHandler.prototype.addListeners = function(type, emitter) {
 
 // Forward streamer data directly to client
 SocketHandler.prototype.streamerSocketForward = function(event, socket) {
+  streamer.removeAllListeners(event)
   streamer.on(event, function(data) {
     socket.emit(event, data);
   });
@@ -129,6 +130,7 @@ SocketHandler.prototype._connect = function(socket) {
   this.streamerSocketForward('trend', socket);
 
   // Send source updates back to client
+  self.removeAllListeners('sourceErrorCountUpdated');
   self.on('sourceErrorCountUpdated', function() {
     self.emitAllErrorsCount(socket);
   });
@@ -170,7 +172,7 @@ SocketHandler.prototype._streamerQueryListen = function(event, QueryType, socket
 // Send data back to client for matching queries
 SocketHandler.prototype._streamerQueryCheck = function(event, QueryType, socket) {
   var self = this;
-
+  streamer.removeAllListeners(event);
   streamer.on(event, function(query, data) {
     var clientQuery = self.clientQuery;
     // Determine if current client query matches the query
@@ -184,7 +186,6 @@ SocketHandler.prototype._streamerQueryCheck = function(event, QueryType, socket)
 
 SocketHandler.prototype._addSourceLocalListeners = function(emitter) {
   var self = this;
-
   // Listens to changes in source metadata
   emitter.on('source:save', function() {
     emitAllSources(self);
@@ -215,6 +216,7 @@ SocketHandler.prototype._addSourceListeners = function(emitter) {
   });
 
   // Send sources to client
+  this.removeAllListeners('sources');
   this.on('sources', function(sources) {
     self.io.sockets.emit('sources', sources);
   });
@@ -257,6 +259,7 @@ SocketHandler.prototype._addTrendsListeners = function(emitter) {
   emitter.removeAllListeners('trend');
 
   // Send trends to client
+  this.removeAllListeners('trend');
   this.on('trend', function(trend) {
     self.io.sockets.emit('trend', trend);
   });


### PR DESCRIPTION
Removed Listeners before Adding them to Prevent Repeated Added Listeners on Refresh

The explanation here is that the Socket-handler and streamer objects were attaching EventListeners to themselves and not removing them before they were called again on refresh. These changes fix that.