### PR TITLE
Query performance upgrade

### DIFF
--- a/models/query/report-query.js
+++ b/models/query/report-query.js
@@ -51,8 +51,9 @@ ReportQuery.prototype.toMongooseFilter = function() {
   filter = _.omitBy(filter, _.isNil);
   if (this.before)    filter.storedAt = { $lte: this.before }
   if (this.after)     filter.storedAt = Object.assign({}, filter.storedAt, { $gte: this.after });
-  if (this.author)    filter.author = { $regex: this.author, $options: 'i'}
-  if (this.keywords)  filter.content = { $regex: this.keywords,  $options: 'i' }
+  if (this.author || this.keywords) filter.$and = [];
+  if (this.author)    filter.$and.push({$text: { $search: this.author}}, {"author": {$regex: this.author, $options: 'i'}});
+  if (this.keywords)  filter.$and.push({$text: { $search: this.keywords}}, {"content": {$regex: this.keywords, $options: 'i'}});
   if (this.tags)      filter.smtcTags = { $all: this.tags }
   if (this.list)      filter["metadata.ct_tag"] = {$in: [this.list] }
   return filter;

--- a/models/query/report-query.js
+++ b/models/query/report-query.js
@@ -53,7 +53,7 @@ ReportQuery.prototype.toMongooseFilter = function() {
   if (this.after)     filter.storedAt = Object.assign({}, filter.storedAt, { $gte: this.after });
   //Two step search for content/author. First search for any terms in content or author using the indexed $text search.
   //Second step is to match exact phrase using regex in the returned superset of the documents from first step.
-  if (this.author || this.keywords) filter.$and = [{$text: { $search: this.author +" "+ this.keywords}}];
+  if (this.author || this.keywords) filter.$and = [{$text: { $search: `${this.author || ""} ${this.keywords || ""}` }}];
   if (this.author)    filter.$and.push({"author": {$regex: this.author, $options: 'i'}});
   if (this.keywords)  filter.$and.push({"content": {$regex: this.keywords, $options: 'i'}});
   if (this.tags)      filter.smtcTags = { $all: this.tags }

--- a/models/report.js
+++ b/models/report.js
@@ -30,8 +30,8 @@ var schema = new Schema({
 });
 
 schema.index({'metadata.ct_tag': 1}, {background: true});
-// Add fulltext index to the `content` field.
-schema.index({ content: 'text' });
+// Add fulltext index to the `content` and `author` field.
+schema.index({ content: 'text', author: 'text' });
 schema.path('_incident').set(function(_incident) {
   this._prevIncident = this._incident;
   return _incident;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8724,7 +8724,7 @@
     "promise": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
       "requires": {
         "asap": "~2.0.6"
       },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28471385/97230042-a59a4a80-17af-11eb-9adb-dd27549f4495.png)

Added $text index for author.

Previously, we were doing regex search on all documents for content and authors. This was taking lots of time because regex search is a time-intensive process. 

In this PR, I changed it to two step process. First we find documents matching any of the terms in content or author in the documents using the $text index (which is very fast). In second step, we do regex matches on the returned set (from first step) to find exact matches. This approach takes much less time than before. 

