### PR TITLE
Added date filter to incident page

### DIFF
--- a/lib/api/v1/incident-controller.js
+++ b/lib/api/v1/incident-controller.js
@@ -147,6 +147,8 @@ module.exports = function(app, user) {
 
 function parseQueryData(queryString) {
   if (!queryString) return {};
+  if (queryString.before) queryString.storedAt = { $lte: queryString.before }
+  if (queryString.after)  queryString.storedAt = Object.assign({}, queryString.storedAt, { $gte: queryString.after });
   var query = _.pick(queryString, Incident.filterAttributes);
   if (query.tags) query.tags = tags.toArray(query.tags);
   return query;

--- a/public/angular/js/controllers/incidents/index.js
+++ b/public/angular/js/controllers/incidents/index.js
@@ -167,8 +167,18 @@ angular.module('Aggie')
       $scope.search({ locationName: null });
     }
 
+    $scope.clearDateFilterFields = function() {
+      $scope.searchParams.after = null; $scope.searchParams.before = null;
+    };
+
+    $scope.clearDateFilter = function() {
+      $scope.search({ after: null, before: null });
+    };
+
     $scope.noFilters = function() {
-      return $scope.searchParams.title === null &&
+      return $scope.searchParams.before === null &&
+        $scope.searchParams.after === null &&
+        $scope.searchParams.title === null &&
         $scope.searchParams.locationName === null &&
         $scope.searchParams.assignedTo === null &&
         $scope.searchParams.status === null &&
@@ -188,7 +198,9 @@ angular.module('Aggie')
         veracity: null,
         tags: null,
         escalated: null,
-        public: null
+        public: null,
+        before: null,
+        after: null,
       });
     };
 

--- a/public/angular/js/routes.js
+++ b/public/angular/js/routes.js
@@ -139,7 +139,7 @@ angular.module('Aggie')
 
 
     $stateProvider.state('incidents', {
-      url: '/incidents?page&title&locationName&assignedTo&status&veracity&tags&escalated&public',
+      url: '/incidents?page&title&locationName&assignedTo&status&veracity&tags&escalated&public&before&after',
       templateUrl: '/templates/incidents/index.html',
       controller: 'IncidentsIndexController',
       resolve: {
@@ -154,7 +154,9 @@ angular.module('Aggie')
             veracity: params.veracity,
             tags: params.tags,
             escalated: params.escalated,
-            public: params.public
+            public: params.public,
+            after: params.after,
+            before: params.before,
           }).$promise;
         }],
         users: ['User', function(User) {

--- a/public/angular/templates/incidents/index.html
+++ b/public/angular/templates/incidents/index.html
@@ -83,6 +83,18 @@
               </div>
               <div class="form-group col-md-auto mb-0 pb-2">
                 <ul class="list-inline mb-0">
+                  <li class="list-inline-item">
+                    <div class="input-group input-group-sm">
+                      <button type="button" class="btn btn-default" ng-controller="DatetimeModalController" ng-click="open()">
+                    <span ng-switch="(searchParams.before && 1) + (searchParams.after && 2)">
+                      <span ng-switch-when="3">{{ 'From' | translate }} <strong>{{searchParams.after | aggieDate : 'datetime' }}</strong> to <strong>{{searchParams.before | aggieDate : 'datetime'}}</strong></span>
+                      <span ng-switch-when="2">{{ 'After' | translate }} <strong>{{searchParams.after | aggieDate : 'datetime' }}</strong></span>
+                      <span ng-switch-when="1">{{ 'Before' | translate }} <strong>{{searchParams.before | aggieDate : 'datetime'}}</strong></span>
+                      <span ng-switch-default translate>Date/Time</span>
+                    </span>
+                      </button>
+                    </div>
+                  </li>
                   <li class="list-inline-item" ng-hide="noFilters()">
                     <div class="input-group input-group-sm">
                       <button type="submit" class="btn btn-secondary" ng-click="clearFilters()" translate>Clear Filters</button>

--- a/shared/incident.js
+++ b/shared/incident.js
@@ -10,7 +10,7 @@
 
   Incident.filterAttributes = [
     'title', 'locationName', 'assignedTo', 'status', 'veracity',
-    'escalated', 'tags', 'public'
+    'escalated', 'tags', 'public', 'storedAt'
   ];
   Incident.statusOptions = ['new', 'working', 'alert', 'closed'];
 


### PR DESCRIPTION
Adds a date filter to the Incident tab that functions identically to one on the Report page.

Note: IncidentQuery is never used outside of tests, so we should either get rid of it, or rewrite the incident controller to use it. For the sake of consistency with the report controller, we should probably use it.