### PR TITLE
Make clicking the "___ new reports" flash refresh the page

### DIFF
--- a/public/angular/js/controllers/reports/index.js
+++ b/public/angular/js/controllers/reports/index.js
@@ -4,6 +4,7 @@ angular.module('Aggie')
   '$scope',
   '$rootScope',
   '$stateParams',
+  '$window',
   'FlashService',
   'reports',
   'sources',
@@ -22,7 +23,7 @@ angular.module('Aggie')
   'paginationOptions',
   '$translate',
   'Settings',
-  function($state, $scope, $rootScope, $stateParams, flash, reports, sources, smtcTags,
+  function($state, $scope, $rootScope, $stateParams, $window, flash, reports, sources, smtcTags,
            mediaOptions, incidents, statusOptions, linkedtoIncidentOptions, ctLists,
            Report, Incident, Batch, Socket, Queue, Tags, paginationOptions,
            $translate, Settings) {
@@ -299,11 +300,14 @@ angular.module('Aggie')
     };
 
     $scope.displayNewReports = function() {
+      // TODO: When attempting to add tags to "new Reports" tags breaks the software. Until this is solved, I'm making this function refresh the page, which solves the issue on its own.
+      $window.location.reload();
+      /*
       var reports = $scope.newReports.toArray();
       reports.forEach(linkify);
       $scope.reports.concat(reports);
       $scope.visibleReports.addMany(reports);
-      $scope.newReports = new Queue(paginationOptions.perPage);
+      $scope.newReports = new Queue(paginationOptions.perPage);*/
     };
 
     $scope.clearDateFilterFields = function() {
@@ -505,10 +509,13 @@ angular.module('Aggie')
      * @param {SMTCTag} smtcTag
      */
     $scope.addTagToSelected = function(smtcTag) {
+      console.log(smtcTag);
       //TODO: There should be a validation that the tag is not already added to the report
       var items = $scope.filterSelected($scope.reports);
       if (!items.length) return;
       var ids = getIds(addSMTCTag(items, smtcTag));
+      console.log(ids);
+      console.log(smtcTag._id);
       Report.addSMTCTag({ids: ids, smtcTag: smtcTag._id});
     };
 


### PR DESCRIPTION
This is a rather rudimentary fix for a tag issue (adding tags to new reports breaks any future ability to add tags to any report) but prevents end-users from breaking the system unintentionally. I left a TODO in there to make the original method work but, this is not outside the realm of how systems behave. When there are new changes to the reports, the page will request you refresh the page.