### PR TITLE
Mataomo Breaks the Front-end If the config settings isn't available.

### DIFF
--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -109,5 +109,8 @@
   "experimentFile": "test/end-to-end/fixtures/experiment_reports.json",
   "adminPassword": "letmein1",
   "adminEmail": "aggie-admin@example.com",
-  "detectHateSpeech": false
+  "detectHateSpeech": false,
+  "matomo": {
+    "enabled": false
+  }
 }

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -109,5 +109,5 @@
   "experimentFile": "test/end-to-end/fixtures/experiment_reports.json",
   "adminPassword": "letmein1",
   "adminEmail": "aggie-admin@example.com",
-  "detectHateSpeech": false,
+  "detectHateSpeech": false
 }

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -110,7 +110,4 @@
   "adminPassword": "letmein1",
   "adminEmail": "aggie-admin@example.com",
   "detectHateSpeech": false,
-  "matomo": {
-    "enabled": false
-  }
 }

--- a/public/angular/js/controllers/application.js
+++ b/public/angular/js/controllers/application.js
@@ -10,11 +10,11 @@ angular.module('Aggie')
     // Set up Matomo analytics.
     settings.get('matomo', function success(data) {
       if (!data.matamo) {
-        console.error("Matomo is not set up in Aggie's configuration");
+        console.warn("Matomo is missing from Aggie's configuration.");
         return;
       }
       if (!data.matomo.enabled) {
-        console.error("Matomo is not correctly set up in Aggie's configuration");
+        console.log("Matomo is disabled.");
         return;
       }
 

--- a/public/angular/js/controllers/application.js
+++ b/public/angular/js/controllers/application.js
@@ -9,7 +9,14 @@ angular.module('Aggie')
 
     // Set up Matomo analytics.
     settings.get('matomo', function success(data) {
-      if (!data.matomo.enabled) return;
+      if (!data.matamo) {
+        console.error("Matomo is not set up in Aggie's configuration");
+        return;
+      }
+      if (!data.matomo.enabled) {
+        console.error("Matomo is not correctly set up in Aggie's configuration");
+        return;
+      }
 
       var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */


### PR DESCRIPTION
The lack of the setting should either prevent the system from working initially or not prevent the front-end from working. I've updated the secrets.json.example and made it so that the front-end still works even if the config was not set.