### PR TITLE
Visualization CT Source title fix

### DIFF
--- a/public/angular/js/controllers/analysis/index.js
+++ b/public/angular/js/controllers/analysis/index.js
@@ -71,7 +71,6 @@ angular
           return out;
         })
         .filter(function (report) {
-          console.log(report);
           return report._incident.titleTags.includes("hate speech");
         });
 

--- a/public/angular/js/controllers/analysis/source-bar.js
+++ b/public/angular/js/controllers/analysis/source-bar.js
@@ -77,7 +77,10 @@ module.exports = function renderSourceBar(id, sources, totalReports, description
         .attr("y", "0.7em")
         .attr("font-weight", "bold")
         .text(function (d) {
-          return d.name.length > 20 ? d.name.slice(0, 20) + '...' : d.name;
+          return d.name.length > 25 ? d.name.slice(0, 25) + '...' : d.name;
+        }).append("title")
+        .text(function (d) {
+          return d.name + "\n" + d.value + " reports";
         });
     })
     .call(function (text) {

--- a/public/angular/js/controllers/analysis/source-bar.js
+++ b/public/angular/js/controllers/analysis/source-bar.js
@@ -77,7 +77,7 @@ module.exports = function renderSourceBar(id, sources, totalReports, description
         .attr("y", "0.7em")
         .attr("font-weight", "bold")
         .text(function (d) {
-          return d.name;
+          return d.name.length > 20 ? d.name.slice(0, 20) + '...' : d.name;
         });
     })
     .call(function (text) {


### PR DESCRIPTION
Truncates CT Source titles that are longer than 25 characters so they don't overlap, and removed unnecessary console log