### PR TITLE
Remove order by status

### DIFF
--- a/public/angular/templates/incidents/table.html
+++ b/public/angular/templates/incidents/table.html
@@ -19,7 +19,7 @@
     </tr>
     </thead>
     <tbody class="table-bordered">
-    <tr ng-repeat="i in incidents | orderBy:['closed','-idnum']" ng-class="{ item: true, 'bg-gray': i.closed }" ng-click="select(i)" >
+    <tr ng-repeat="i in incidents | orderBy:['-idnum']" ng-class="{ item: true, 'bg-gray': i.closed }" ng-click="select(i)" >
       <th scope="row" class="text-center table__checkbox" ng-hide="modal || !currentUser.can('edit data')">
         <div class="td__checkbox">
           <input class="checkbox__input" ng-model="i.selected" type="checkbox" ng-model="i._id"/>


### PR DESCRIPTION
**Description:** Incidents should be ordered in pagination by their ID number, with the highest number on the earliest page. Instead there is some sort of priority given to open incidents by default. This is nonsensical and makes it difficult for users to find the incident they want by ID.

Removed the ordering by status for the incident table. The change can be observed by going to the incident page, and having a bunch of incidents that are a mix of open and closed. The closed incidents do not migrate to the bottom of the list anymore. 