### PR TITLE
Fixed Bug

### DIFF
--- a/public/angular/js/controllers/reports/index.js
+++ b/public/angular/js/controllers/reports/index.js
@@ -196,9 +196,13 @@ angular.module('Aggie')
     }
 
     var updateTagSearchNames = function() {
-      if ($scope.searchParams.tags) {
+      var tempTags = $scope.searchParams.tags;
+      if (tempTags) {
+        if(typeof tempTags=="string"){
+          tempTags = [tempTags];
+        }
         var tagNames = "";
-        tagNames = $scope.searchParams.tags.map(function(tagId) {
+        tagNames = tempTags.map(function(tagId) {
           if ($scope.smtcTagsById[tagId]) { return $scope.smtcTagsById[tagId].name; }
           else { return tagId; }
         });


### PR DESCRIPTION
Fixed the pagination bug with a quick fix within the problem function to handle when it is passed a string rather than an array of string. However, it might be good to eventually hunt down where $scope.searchParams.tags is not being put into a list when a single tag is searched and not on the first page.