### PR TITLE
Facebook docs update

### DIFF
--- a/docs/content/settings/settings.md
+++ b/docs/content/settings/settings.md
@@ -31,7 +31,7 @@ Fetching can be enabled or disabled by toggling ON/OFF the fetching toggle. To t
 
     ![Media Authentication](toggle3.png)
 
-3. Click on **Edit** to authenticate the Twitter, Crowdtangle, or Elmo feed settings.
+3. Click on **Edit** to authenticate the Twitter, Facebook, or Elmo feed settings.
 
     ![Media Authentication](social_media_feed_authentication.png)
 

--- a/docs/content/usingaggie/usingaggie.md
+++ b/docs/content/usingaggie/usingaggie.md
@@ -4,7 +4,7 @@
 
 ### What is a Source?
 
-Sources are the social media platforms such as *Twitter, Crowdtangle, Ushahidi, and RSS feeds* that Aggie crawls through to aggregate reports relevant to the event being monitored.
+Sources are the social media platforms such as *Twitter, Facebook, Ushahidi, and RSS feeds* that Aggie crawls through to aggregate reports relevant to the event being monitored.
 
 Sources can also be services that send reports directly to Aggie. Currently, we have implemented support for WhatsApp and [SMSGH](https://hubtel.com/messaging/), a service that forwards SMS text messages sent to [short codes](https://en.wikipedia.org/wiki/Short_code).
 


### PR DESCRIPTION
Updated last remaining references of Crowdtangle to Facebook. Much of the docs use the term Facebook already.